### PR TITLE
Feat/g0 step1 a post api

### DIFF
--- a/ingest-api/src/main/java/com/teamA/async/ingest/api/ParticipationController.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/api/ParticipationController.java
@@ -1,0 +1,23 @@
+package com.teamA.async.ingest.api;
+
+import com.teamA.async.ingest.api.dto.ParticipationResponse;
+import com.teamA.async.ingest.auth.UserResolver;
+import com.teamA.async.ingest.service.ParticipationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ParticipationController {
+
+    private final ParticipationService participationService;
+    private final UserResolver userResolver;
+
+    @PostMapping("/events/{eventId}/participations")
+    public ResponseEntity<ParticipationResponse> participate(@PathVariable String eventId) {
+        String userId = userResolver.currentUserId(); // JWT에서만 추출
+        ParticipationResponse res = participationService.participate(eventId, userId);
+        return ResponseEntity.accepted().body(res); // 항상 202
+    }
+}

--- a/ingest-api/src/main/java/com/teamA/async/ingest/api/dto/ParticipationResponse.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/api/dto/ParticipationResponse.java
@@ -1,0 +1,6 @@
+package com.teamA.async.ingest.api.dto;
+
+public record ParticipationResponse(
+        String requestId,
+        boolean isDuplicate
+) {}

--- a/ingest-api/src/main/java/com/teamA/async/ingest/auth/UserResolver.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/auth/UserResolver.java
@@ -1,0 +1,20 @@
+package com.teamA.async.ingest.auth;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * G0 단계용 임시 UserResolver
+ *
+ * ❗주의
+ * - 실제 인증/인가 로직 아님
+ * - Step1에서는 "userId 공급자" 역할만 수행
+ * - G1에서 JWT / SecurityContext 기반 구현으로 교체 예정
+ */
+@Component
+public class UserResolver {
+
+    public String currentUserId() {
+        // TODO G1: SecurityContext / JWT Claim에서 추출
+        return "user-001";
+    }
+}

--- a/ingest-api/src/main/java/com/teamA/async/ingest/config/DynamoDbConfig.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/config/DynamoDbConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -12,10 +13,13 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 public class DynamoDbConfig {
 
     @Bean
-    public DynamoDbClient dynamoDbClient(@Value("${aws.region}") String region) {
+    public DynamoDbClient dynamoDbClient(
+            @Value("${aws.region}") String region,
+            @Value("${aws.profile:wish}") String profile
+    ) {
         return DynamoDbClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create())
+                .credentialsProvider(ProfileCredentialsProvider.create(profile))
                 .build();
     }
 

--- a/ingest-api/src/main/java/com/teamA/async/ingest/ddb/IdempotencyRepository.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/ddb/IdempotencyRepository.java
@@ -1,0 +1,66 @@
+package com.teamA.async.ingest.ddb;
+
+import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class IdempotencyRepository {
+
+    private final DynamoDbClient dynamoDbClient;
+
+    @Value("${ddb.table-name}")
+    private String tableName;
+
+    private static final String ATTR_PK = "PK";
+    private static final String ATTR_SK = "SK";
+    private static final String ATTR_REQUEST_ID = "requestId";
+
+    public boolean tryLock(String idempotencyPk, String requestId) {
+        Map<String, AttributeValue> item = Map.of(
+                ATTR_PK, AttributeValue.builder().s(idempotencyPk).build(),
+                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.lockSk()).build(),
+                ATTR_REQUEST_ID, AttributeValue.builder().s(requestId).build()
+        );
+
+        // attribute_not_exists(PK) AND attribute_not_exists(SK)
+        // (PK만으로도 충분한데, 문서 규칙 그대로 반영)
+        PutItemRequest req = PutItemRequest.builder()
+                .tableName(tableName)
+                .item(item)
+                .conditionExpression("attribute_not_exists(#pk) AND attribute_not_exists(#sk)")
+                .expressionAttributeNames(Map.of("#pk", ATTR_PK, "#sk", ATTR_SK))
+                .build();
+
+        try {
+            dynamoDbClient.putItem(req);
+            return true;
+        } catch (ConditionalCheckFailedException e) {
+            return false;
+        }
+    }
+
+    public String getRequestId(String idempotencyPk) {
+        Map<String, AttributeValue> key = Map.of(
+                ATTR_PK, AttributeValue.builder().s(idempotencyPk).build(),
+                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.lockSk()).build()
+        );
+
+        GetItemResponse res = dynamoDbClient.getItem(GetItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                .consistentRead(true)
+                .build());
+
+        if (!res.hasItem()) return null;
+
+        AttributeValue v = res.item().get(ATTR_REQUEST_ID);
+        return v == null ? null : v.s();
+    }
+}

--- a/ingest-api/src/main/java/com/teamA/async/ingest/ddb/RequestWriteRepository.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/ddb/RequestWriteRepository.java
@@ -1,0 +1,51 @@
+package com.teamA.async.ingest.ddb;
+
+import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import com.teamA.async.common.domain.model.RequestItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class RequestWriteRepository {
+
+    private final DynamoDbClient dynamoDbClient;
+
+    @Value("${ddb.table-name}")
+    private String tableName;
+
+    public void putReceived(RequestItem item) {
+        if (item.getRequestId() == null || item.getEventId() == null || item.getUserId() == null) {
+            throw new IllegalStateException("requestId/eventId/userId must not be null");
+        }
+
+        // ✅ RECEIVED에서는 base key만 세팅 (GSI는 세팅 금지)
+        item.setPk(DdbKeyFactory.requestPk(item.getRequestId()));
+        item.setSk(DdbKeyFactory.metaSk());
+
+        Map<String, AttributeValue> map = new HashMap<>();
+        map.put("PK", AttributeValue.builder().s(item.getPk()).build());
+        map.put("SK", AttributeValue.builder().s(item.getSk()).build());
+
+        // 도메인 필드
+        map.put("requestId", AttributeValue.builder().s(item.getRequestId()).build());
+        map.put("eventId", AttributeValue.builder().s(item.getEventId()).build());
+        map.put("userId", AttributeValue.builder().s(item.getUserId()).build());
+        map.put("status", AttributeValue.builder().s(item.getStatus().name()).build());
+        map.put("requestedAt", AttributeValue.builder().n(Long.toString(item.getRequestedAt())).build());
+
+        // ❌ GSI1PK/GSI1SK/GSI2PK/GSI2SK는 절대 넣지 않음 (RECEIVED 단계 규칙)
+
+        dynamoDbClient.putItem(PutItemRequest.builder()
+                .tableName(tableName)
+                .item(map)
+                .build());
+    }
+}

--- a/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
@@ -1,0 +1,61 @@
+package com.teamA.async.ingest.service;
+
+import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.model.RequestItem;
+import com.teamA.async.ingest.api.dto.ParticipationResponse;
+import com.teamA.async.ingest.ddb.IdempotencyRepository;
+import com.teamA.async.ingest.ddb.RequestWriteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipationService {
+
+    private final IdempotencyRepository idempotencyRepository;
+    private final RequestWriteRepository requestWriteRepository;
+
+    // 시간은 우선 System.currentTimeMillis()로 가고, 나중에 common Clock으로 교체해도 됨
+    public ParticipationResponse participate(String eventId, String userId) {
+        String idempotencyPk = DdbKeyFactory.idempotencyPk(eventId, userId);
+
+        // 1) Lock 시도 (Conditional Put)
+        String newRequestId = newRequestId();
+        boolean locked = idempotencyRepository.tryLock(idempotencyPk, newRequestId);
+
+        // 2-A) Lock 실패 => 기존 requestId 반환 (새 requestId 생성 금지 정책 충족)
+        if (!locked) {
+            String existing = idempotencyRepository.getRequestId(idempotencyPk);
+            // 여기서 existing이 null이면 데이터 이상 케이스인데, G0에선 일단 예외로 터뜨려도 OK
+            if (existing == null) {
+                throw new IllegalStateException("Idempotency lock exists but requestId missing: " + idempotencyPk);
+            }
+            return new ParticipationResponse(existing, true);
+        }
+
+        // 2-B) Lock 성공 => RequestItem (RECEIVED) 생성 (GSI 미세팅)
+        long now = System.currentTimeMillis();
+        RequestItem item = RequestItem.builder()
+                .requestId(newRequestId)
+                .eventId(eventId)
+                .userId(userId)
+                .status(RequestStatus.RECEIVED)
+                .requestedAt(now)
+                .build();
+
+        // ❗ G0 규칙: RECEIVED 단계에서는 GSI 세팅하지 않음
+        // 지금 RequestItem.generateKeys()는 GSI도 생성해버리니까, "RECEIVED 전용 키 생성"을 분리하는 걸 추천.
+        // 일단 여기서는 base key만 set하도록 repository에서 강제한다.
+        requestWriteRepository.putReceived(item);
+
+        return new ParticipationResponse(newRequestId, false);
+    }
+
+    private String newRequestId() {
+        // 형식은 팀 규칙대로. 우선 UUID short 형태
+        return "REQ-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/ingest-api/src/main/resources/application.yml
+++ b/ingest-api/src/main/resources/application.yml
@@ -8,7 +8,7 @@ management:
         include: health,info
 aws:
   region: ${AWS_REGION:ap-northeast-2}
-  profile: wish //여기 iam 롤에 맞춰 변경!
+  profile: wish
   dynamodb:
     table-name: ${DDB_TABLE_NAME:AsyncEventTable}
   sqs:
@@ -19,3 +19,6 @@ logging:
     root: INFO
     software.amazon.awssdk: INFO
     com.team.async: DEBUG
+
+ddb:
+  table-name: AsyncEventTable


### PR DESCRIPTION
## 📌 작업 내용
- IdempotencyLock(DynamoDB Conditional Put) 기반 중복 요청 차단
- 동일 유저의 연속 요청이 단일 requestId로 수렴하도록 처리
- Lock 성공 시에만 requestId 생성 및 RequestItem(RECEIVED) 최초 생성
- Lock 실패 시 기존 requestId 조회 후 202 Accepted + isDuplicate 반환
- 상태 전이는 수행하지 않고 상태 머신의 진입점만 생성하도록 제한

## 🔍 작업 상세
- [x] POST /events/{eventId}/participations (부분 구현)
    - IdempotencyLock Conditional Put
      -  PK = IDEMP#<eventId>#<userId>
      - SK = LOCK
- [x] Lock 성공 시 신규 requestId 생성, RequestItem 최초 생성(status = RECEIVED, requestedAt 기록, GSI 필드 미설정)
- [x] Lock 실패 시 기존 requestId 조회, 202 Accepted + isDuplicate=true 응답 반환

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- 간단한 테스트 결과를 적어주세요 (예: Postman 결과 캡처 등)
첫번째 클릭
<img width="478" height="239" alt="image (3)" src="https://github.com/user-attachments/assets/f9d1091d-3373-4c09-8b13-ca20f703ea5a" />

<br>
바로 두 번째 클릭
<img width="464" height="235" alt="image (4)" src="https://github.com/user-attachments/assets/30eaf2f5-aa4d-4c57-afdf-ad03159f9f75" />
<br>
DynamoDB에서 IdempotencyLock이 1개만 존재, Item 1개, requestId 속성이 들어있고, 값이 위에서 받은
값과 같음
<img width="959" height="397" alt="image (5)" src="https://github.com/user-attachments/assets/de634ae6-7558-4a4d-b2dc-9d76b4a98ba7" />

<br>
RequestItem이 RECEIVED로 정확히 1번 생성되는지 확인
<img width="464" height="403" alt="image (6)" src="https://github.com/user-attachments/assets/1ffbbe2a-6b71-4675-b936-6d307efa750d" />
<img width="1018" height="83" alt="image (7)" src="https://github.com/user-attachments/assets/a351acbb-ab79-49b5-9fd0-e3032be8ba36" />

<br>
동시성 테스트

1..10 | ForEach-Object { Start-Job { curl -X POST http://localhost:8080/events/EVT-001/participations } } | Wait-Job | Receive-Jo
<img width="351" height="641" alt="image (8)" src="https://github.com/user-attachments/assets/dba2a159-ca74-4e0e-8fe7-b0a1fc8c695c" />
b


## 🗨 기타 참고 사항
- 이슈 번호: #5 
- 논의가 필요한 부분이 있다면 여기에 작성해주세요.
