### PR TITLE
feat: 운영자 조회 API 구현

### DIFF
--- a/common/src/main/java/com/teamA/async/common/domain/dto/AdminEventRequestItem.java
+++ b/common/src/main/java/com/teamA/async/common/domain/dto/AdminEventRequestItem.java
@@ -1,0 +1,35 @@
+package com.teamA.async.common.domain.dto;
+
+import com.teamA.async.common.domain.enums.EventType;
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.enums.ResultCode;
+import com.teamA.async.common.domain.enums.UiResult;
+import com.teamA.async.common.domain.model.RequestItem;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminEventRequestItem {
+    private String requestId;
+    private String eventId;
+    private String userId;
+    private EventType eventType;
+    private RequestStatus status;
+    private UiResult uiResult;
+    private ResultCode resultCode;
+    private Long queuedAt;
+
+    public static AdminEventRequestItem from(RequestItem item) {
+        return AdminEventRequestItem.builder()
+                .requestId(item.getRequestId())
+                .eventId(item.getEventId())
+                .userId(item.getUserId())
+                .eventType(item.getEventType())
+                .status(item.getStatus())
+                .uiResult(item.getUiResult() == null ? UiResult.PENDING : item.getUiResult())
+                .resultCode(item.getResultCode())
+                .queuedAt(item.getQueuedAt())
+                .build();
+    }
+}

--- a/common/src/main/java/com/teamA/async/common/domain/model/RequestItem.java
+++ b/common/src/main/java/com/teamA/async/common/domain/model/RequestItem.java
@@ -50,7 +50,7 @@ public class RequestItem {
     public String getGsi1Sk() { return gsi1Sk; }
 
     // GSI2: 이벤트별/관리자 조회
-    // PK: EVENT#{eventId} / SK: QAT#{queuedAt}#ST#{status}#REQ#{requestId}
+    // PK: EVENT#{eventId} / SK: QAT#{queuedAt}#ST#{status}#REQ#{requestId}  // status 포함 금지
     private String gsi2Pk;
     private String gsi2Sk;
 

--- a/common/src/main/resources/application.yml
+++ b/common/src/main/resources/application.yml
@@ -3,4 +3,4 @@ ddb:
 
 aws:
   region: ap-northeast-2
-  profile: hyeyun
+  profile: wish

--- a/ingest-api/src/main/java/com/teamA/async/ingest/api/AdminRequestQueryController.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/api/AdminRequestQueryController.java
@@ -1,0 +1,107 @@
+package com.teamA.async.ingest.api;
+
+import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import com.teamA.async.common.domain.dto.AdminEventRequestItem;
+import com.teamA.async.common.domain.dto.RequestStatusResponse;
+import com.teamA.async.common.domain.enums.UiResult;
+import com.teamA.async.common.domain.model.RequestItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import software.amazon.awssdk.enhanced.dynamodb.*;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminRequestQueryController {
+
+    private final DynamoDbEnhancedClient enhancedClient;
+
+    @Value("${aws.dynamodb.table-name}")
+    private String tableName;
+
+    private static final int DEFAULT_LIMIT = 100;
+    private static final int MAX_LIMIT = 100;
+
+    private DynamoDbTable<RequestItem> table() {
+        return enhancedClient.table(tableName, TableSchema.fromBean(RequestItem.class));
+    }
+
+    // 1) Admin 단건 조회
+    @GetMapping("/admin/requests/{requestId}")
+    public ResponseEntity<RequestStatusResponse> getAdminRequest(@PathVariable String requestId) {
+        Key key = Key.builder()
+                .partitionValue(DdbKeyFactory.requestPk(requestId))
+                .sortValue(DdbKeyFactory.metaSk())
+                .build();
+
+        RequestItem item = table().getItem(r -> r.key(key).consistentRead(true));
+        if (item == null) return ResponseEntity.notFound().build();
+
+        UiResult uiResult = item.getUiResult() == null ? UiResult.PENDING : item.getUiResult();
+
+        return ResponseEntity.ok(RequestStatusResponse.builder()
+                .requestId(item.getRequestId())
+                .eventId(item.getEventId())
+                .eventType(item.getEventType())
+                .status(item.getStatus())
+                .uiResult(uiResult)
+                .resultCode(item.getResultCode())
+                .timestamps(RequestStatusResponse.Timestamps.builder()
+                        .requestedAt(item.getRequestedAt())
+                        .queuedAt(item.getQueuedAt())
+                        .startedAt(item.getStartedAt())
+                        .finishedAt(item.getFinishedAt())
+                        .build())
+                .build());
+    }
+
+    // 2) Admin 이벤트별 목록 조회 (GSI2)
+    @GetMapping("/admin/events/{eventId}/requests")
+    public ResponseEntity<List<AdminEventRequestItem>> getAdminEventRequests(
+            @PathVariable String eventId,
+            @RequestParam(required = false) Integer limit
+    ) {
+        int lim = clampLimit(limit);
+
+        Key gsiKey = Key.builder()
+                .partitionValue(DdbKeyFactory.eventPk(eventId))
+                .build();
+
+        List<AdminEventRequestItem> result = new ArrayList<>(lim);
+
+        Iterator<Page<RequestItem>> it = table()
+                .index("GSI2")
+                .query(q -> q.queryConditional(QueryConditional.keyEqualTo(gsiKey))
+                        .scanIndexForward(false)
+                        .limit(lim))
+                .iterator();
+
+        while (it.hasNext() && result.size() < lim) {
+            Page<RequestItem> page = it.next();
+            for (RequestItem item : page.items()) {
+                result.add(AdminEventRequestItem.from(item));
+                if (result.size() >= lim) break;
+            }
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+    private int clampLimit(Integer limit) {
+        if (limit == null) return DEFAULT_LIMIT;
+        if (limit < 1) return 1;
+        return Math.min(limit, MAX_LIMIT);
+    }
+}
+


### PR DESCRIPTION
related to #32

## 📌 작업 내용
G0 단계에서 운영자(CS/장애 대응)가  
requestId 또는 eventId 기준으로 비동기 요청 상태를 즉시 조회할 수 있도록  Admin 조회 API를 구현했습니다.

## 🔍 작업 상세
- [x] GET /admin/requests/{requestId}
  - DynamoDB GetItem 사용
    - PK = `REQ#<requestId>`
    - SK = `META`
  - 요청 상태, timestamps, resultCode 반환
  - requestId 미존재 시 `404` 반환
- [x] Admin 이벤트별 목록 조회 
  - `GET /admin/events/{eventId}/requests?limit=100`
  - DynamoDB GSI2 Query만 사용
    - `GSI2PK = EVENT#<eventId>`
    - `ScanIndexForward = false` (queuedAt 최신순)
    - `limit` 최대 100으로 clamp
  - Scan 사용 X
  - GSI2SK 불변 규칙 준수  
    - `QAT#<queuedAt>#REQ#<requestId>`
    - status 포함 X
  - QUEUED 이후 요청만 조회됨 (GSI 설계로 보장)

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
<img width="399" height="367" alt="image" src="https://github.com/user-attachments/assets/0720b3c7-b611-4882-8e72-f33276bd6c5b" />


<img width="482" height="226" alt="image" src="https://github.com/user-attachments/assets/6aebf426-9198-4d9e-a3d9-161a74ba9253" />

<img width="488" height="398" alt="image" src="https://github.com/user-attachments/assets/4cd85411-6d77-472c-baa9-66548d7aabf4" />


## 🗨 기타 참고 사항
- 이슈 번호: #32 
 Worker의 최종 상태 전이(`PROCESSING → REJECTED / FAILED_FINAL`)는 별도 이슈에서 진행 중이며, 해당 구현 완료 후 상태 확인 예정입니다.
