### PR TITLE
feat/g1-step2-eventSchema

### DIFF
--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -13,6 +13,9 @@ java {
 dependencies {
     implementation project(':common')
 
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+
     implementation platform('software.amazon.awssdk:bom:2.29.0')
     implementation 'software.amazon.awssdk:dynamodb'
 
@@ -33,7 +36,6 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
-
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedDelivery.java
+++ b/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedDelivery.java
@@ -1,0 +1,12 @@
+package com.teamA.async.worker.analytics.event;
+
+//이 이벤트가 몇번째 시도로 처리되었는지/ dlq에서 온건지
+public record ParticipationProcessedDelivery(
+        int attempt, //몇 번쨰 수신/처리 시도인지
+        boolean isDlq //이 이벤트가 DLQ에서 소비된 메시지의 최종 이벤트인지
+) {
+    public ParticipationProcessedDelivery {
+        //attempt가 0이면 “시도 횟수” 개념이 무너지니 최소 1로 강제
+        if (attempt <= 0) throw new IllegalArgumentException("attempt must be positive");
+    }
+}

--- a/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedEvent.java
+++ b/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedEvent.java
@@ -1,0 +1,72 @@
+package com.teamA.async.worker.analytics.event;
+
+import com.teamA.async.common.domain.enums.EventType;
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.enums.ResultCode;
+
+//이벤트 한 건에 대한-Athena에서 한이벤트를 한줄로 분석할때, 필드가 누락되거나 구조가 뒤틀리지않도록 스키마를 코드로 고정
+public record ParticipationProcessedEvent(
+        int schemaVersion,
+        String env,//이 이벤트가 어디 환경에서 발생했는지(ex. dev/prod)
+
+        String eventId,
+        String requestId,
+        String userId,
+
+        EventType eventType,
+        RequestStatus finalStatus, //SUCCEEDED/REJECTED/FAILED_FINAL
+        ResultCode resultCode, //SUCCESS/REJECTED_CAPACITY
+
+        ParticipationProcessedTimestamps timestamps, //queuedAt을 기준으로 대기/전체 지연을 계산
+        ParticipationProcessedDelivery delivery, //메시지가 몇 번째 시도로 처리됐는지 / DLQ 메시지
+        ParticipationProcessedFailure failure, //실패 관련 추가 정보-실패가 아닌경우 null일 수 있음
+        ParticipationProcessedMeta meta
+) {
+    //record 생성 시 검증
+    public ParticipationProcessedEvent {
+        // Step2 목적: "필드 누락 방지" -> 생성 시점에 강제 검증
+        if (schemaVersion <= 0) throw new IllegalArgumentException("schemaVersion must be positive");
+        if (env == null || env.isBlank()) throw new IllegalArgumentException("env is required");
+
+        if (eventId == null || eventId.isBlank()) throw new IllegalArgumentException("eventId is required");
+        if (requestId == null || requestId.isBlank()) throw new IllegalArgumentException("requestId is required");
+        if (userId == null || userId.isBlank()) throw new IllegalArgumentException("userId is required");
+
+        if (eventType == null) throw new IllegalArgumentException("eventType is required");
+        if (finalStatus == null) throw new IllegalArgumentException("finalStatus is required");
+        if (resultCode == null) throw new IllegalArgumentException("resultCode is required");
+
+        //timestamps/delivery/failure/meta는 “중첩 객체 구조”를 고정하기 위한 필드
+        if (timestamps == null) throw new IllegalArgumentException("timestamps is required");
+        if (delivery == null) throw new IllegalArgumentException("delivery is required");
+        if (failure == null) throw new IllegalArgumentException("failure is required"); // ⭐ 문서 스키마 고정용
+        if (meta == null) throw new IllegalArgumentException("meta is required");
+    }
+
+    /**
+     * 성공/거절 등 "실패 상세 없음" 케이스에서도 failure 객체는 유지하고 내부만 null로 둔다.
+     * (ObjectMapper가 null 제거 안 하므로)
+     */
+    public static ParticipationProcessedEvent noFailure(
+            int schemaVersion,
+            String env,
+            String eventId,
+            String requestId,
+            String userId,
+            EventType eventType,
+            RequestStatus finalStatus,
+            ResultCode resultCode,
+            ParticipationProcessedTimestamps timestamps,
+            ParticipationProcessedDelivery delivery,
+            ParticipationProcessedMeta meta
+    ) {
+        return new ParticipationProcessedEvent(
+                schemaVersion, env,
+                eventId, requestId, userId,
+                eventType, finalStatus, resultCode,
+                timestamps, delivery,
+                new ParticipationProcessedFailure(null, null, null),
+                meta
+        );
+    }
+}

--- a/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedFailure.java
+++ b/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedFailure.java
@@ -1,0 +1,10 @@
+package com.teamA.async.worker.analytics.event;
+
+import com.teamA.async.common.domain.enums.FailureClass;
+//실패일때-실패 분류/에러 정보
+//성공/거절 같은 정상 흐름이면 이 안의 값들이 null 일 수 있음
+public record ParticipationProcessedFailure(
+        FailureClass failureClass, //실패가 재시도 가능한지 아닌지
+        String errorCode, //내부적으로 규정한 에러 코드(예: FAILED_XXX)
+        String errorMessage //디버깅용 메시지(운영에서 원인 파악 용도)
+) {}

--- a/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedMeta.java
+++ b/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedMeta.java
@@ -1,0 +1,10 @@
+package com.teamA.async.worker.analytics.event;
+
+//운영/추적에 유용한 부가정보
+public record ParticipationProcessedMeta(
+        String workerId
+) {
+    public ParticipationProcessedMeta {
+        if (workerId == null || workerId.isBlank()) throw new IllegalArgumentException("workerId is required");
+    }
+}

--- a/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedTimestamps.java
+++ b/worker/src/main/java/com/teamA/async/worker/analytics/event/ParticipationProcessedTimestamps.java
@@ -1,0 +1,15 @@
+package com.teamA.async.worker.analytics.event;
+
+//지표 계산에 필요한 시간관련 3가지
+public record ParticipationProcessedTimestamps(
+        long queuedAt,
+        long startedAt,
+        long finishedAt
+) {
+    public ParticipationProcessedTimestamps {
+        // Step0 고정: queuedAt은 "존재"해야 함 (생성은 Step3에서 금지 / 계승)
+        if (queuedAt <= 0) throw new IllegalArgumentException("queuedAt must be positive");
+        if (startedAt <= 0) throw new IllegalArgumentException("startedAt must be positive");
+        if (finishedAt <= 0) throw new IllegalArgumentException("finishedAt must be positive");
+    }
+}

--- a/worker/src/test/java/com/teamA/async/worker/analytics/event/ParticipationProcessedEventSerializationTest.java
+++ b/worker/src/test/java/com/teamA/async/worker/analytics/event/ParticipationProcessedEventSerializationTest.java
@@ -1,0 +1,60 @@
+package com.teamA.async.worker.analytics.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamA.async.common.domain.enums.EventType;
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.enums.ResultCode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParticipationProcessedEventSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldSerializeParticipationProcessedEventWithExactSchema() throws Exception {
+        ParticipationProcessedEvent event =
+                ParticipationProcessedEvent.noFailure(
+                        1,
+                        "dev",
+                        "EVT-001",
+                        "REQ-123",
+                        "user-1",
+                        EventType.FIRST_COME,
+                        RequestStatus.SUCCEEDED,
+                        ResultCode.SUCCESS,
+                        new ParticipationProcessedTimestamps(
+                                1704290000000L,
+                                1704290000100L,
+                                1704290000200L
+                        ),
+                        new ParticipationProcessedDelivery(1, false),
+                        new ParticipationProcessedMeta("worker-local")
+                );
+
+        String json = objectMapper.writeValueAsString(event);
+
+        assertThat(json).contains("\"schemaVersion\":1");
+        assertThat(json).contains("\"env\":\"dev\"");
+        assertThat(json).contains("\"eventId\":\"EVT-001\"");
+        assertThat(json).contains("\"requestId\":\"REQ-123\"");
+        assertThat(json).contains("\"userId\":\"user-1\"");
+        assertThat(json).contains("\"eventType\":\"FIRST_COME\"");
+        assertThat(json).contains("\"finalStatus\":\"SUCCEEDED\"");
+        assertThat(json).contains("\"resultCode\":\"SUCCESS\"");
+
+        assertThat(json).contains("\"timestamps\"");
+        assertThat(json).contains("\"queuedAt\":1704290000000");
+        assertThat(json).contains("\"startedAt\":1704290000100");
+        assertThat(json).contains("\"finishedAt\":1704290000200");
+
+        assertThat(json).contains("\"delivery\"");
+        assertThat(json).contains("\"attempt\":1");
+        assertThat(json).contains("\"isDlq\":false");
+
+        assertThat(json).contains("\"failure\"");
+        assertThat(json).contains("\"meta\"");
+        assertThat(json).contains("\"workerId\":\"worker-local\"");
+    }
+}


### PR DESCRIPTION
related to #37

## 📌 작업 내용
G1 단계에서 로그 기반 확인을 벗어나 이벤트 데이터 기반 분석이 가능하도록,  
Worker가 발행하는 `ParticipationProcessed` 이벤트의 **스키마를 코드로 고정**했습니다.  
이를 통해 필드 누락이나 형식 변경으로 인해 Athena 분석이 깨지는 상황을 사전에 방지합니다.

## 🔍 작업 상세
- [x] `ParticipationProcessedEvent` 이벤트 DTO/record 정의
- [x] 이벤트 payload 필수 필드 전부 포함
  - schemaVersion / env
  - eventId / requestId / userId / eventType
  - finalStatus / resultCode
- [x] timestamps 구조 정의 (queuedAt / startedAt / finishedAt)
- [x] delivery 구조 정의 (attempt / isDlq)
- [x] failure 구조 정의 (failureClass / errorCode / errorMessage)
- [x] meta 구조 정의 (workerId)
- [x] Jackson 직렬화 결과가 G1 문서의 JSON 예시와 동일함을 로컬 테스트로 검증
- [x] userId는 JWT에서 유도된 값임을 전제로 스키마에 포함 (클라이언트 제공 userId 금지)

## 🧪 테스트 결과
- [x] JUnit 테스트 완료  
  - `ParticipationProcessedEventSerializationTest`를 통해  
    JSON 직렬화 결과가 문서 스키마와 동일함을 검증
<img width="2618" height="931" alt="image" src="https://github.com/user-attachments/assets/2355822c-539a-4a24-86d7-5d7dc280623a" />

## 🗨 기타 참고 사항
- 이 PR은 **이벤트 스키마 정의 및 고정만**을 범위로 합니다.
- EventBridge `putEvents` 호출 및 실제 이벤트 발행 로직은 **Step 3**에서 진행 예정입니다.
- 추후 스키마 확장이 필요할 경우, 필드 삭제/변경 없이 **`meta` 하위 확장만 허용**합니다.
- 본 작업은 PR Reject 방지를 위한 **“스키마 잠금 단계”**입니다.
