### PR TITLE
feat: 처리 결과 EventBridge 발행 및 S3 Data Lake 적재 연결 (Step3 완료)

### DIFF
--- a/common/src/main/java/com/teamA/async/common/domain/enums/ResultCode.java
+++ b/common/src/main/java/com/teamA/async/common/domain/enums/ResultCode.java
@@ -3,5 +3,7 @@ package com.teamA.async.common.domain.enums;
 public enum ResultCode {
     SUCCESS,
     REJECTED_CAPACITY,
-    FAILED_INGEST_ENQUEUE
+    FAILED_INGEST_ENQUEUE,
+    FAILED_INVALID_MESSAGE,
+    FAILED_WORKER_EXCEPTION
 }

--- a/common/src/main/java/com/teamA/async/common/messaging/ParticipationMessage.java
+++ b/common/src/main/java/com/teamA/async/common/messaging/ParticipationMessage.java
@@ -7,19 +7,28 @@ import com.teamA.async.common.domain.enums.EventType;
 public record ParticipationMessage(
         String requestId,
         String eventId,
+        String userId,
+        long queuedAt,
         EventType eventType
 ) {
     @JsonCreator
     public ParticipationMessage(
             @JsonProperty("requestId") String requestId,
             @JsonProperty("eventId") String eventId,
+            @JsonProperty("userId") String userId,
+            @JsonProperty("queuedAt") long queuedAt,
             @JsonProperty("eventType") EventType eventType
     ) {
         if (requestId == null || requestId.isBlank()) throw new IllegalArgumentException("requestId is required");
         if (eventId == null || eventId.isBlank()) throw new IllegalArgumentException("eventId is required");
+        if (userId == null || userId.isBlank()) throw new IllegalArgumentException("userId is required");
+        if (queuedAt <= 0) throw new IllegalArgumentException("queuedAt must be positive");
         if (eventType == null) throw new IllegalArgumentException("eventType is required");
+
         this.requestId = requestId;
         this.eventId = eventId;
+        this.userId = userId;
+        this.queuedAt = queuedAt;
         this.eventType = eventType;
     }
 }

--- a/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
@@ -69,19 +70,46 @@ public class ParticipationService {
         requestWriteRepository.putReceived(item);
 
         try {
-            // 3) SQS enqueue
-            ParticipationMessage msg =
-                    new ParticipationMessage(newRequestId, eventId, EventType.FIRST_COME);
+            // 3) SQS enqueue 전에 queuedAt 확정 (Worker 생성 금지 규칙)
+            long queuedAt = System.currentTimeMillis();
+
+            ParticipationMessage msg = new ParticipationMessage(
+                    newRequestId, eventId, userId, queuedAt, EventType.FIRST_COME
+            );
 
             String body = objectMapper.writeValueAsString(msg);
+
+            Map<String, MessageAttributeValue> attributes = Map.of(
+                    "requestId", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(newRequestId)
+                            .build(),
+                    "eventId", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(eventId)
+                            .build(),
+                    "userId", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(userId)
+                            .build(),
+                    "eventType", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(EventType.FIRST_COME.name())
+                            .build(),
+                    "queuedAt", MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(Long.toString(queuedAt))
+                            .build()
+            );
 
             sqsClient.sendMessage(r -> r
                     .queueUrl(queueUrl)
                     .messageBody(body)
+                    .messageAttributes(attributes)
             );
 
-            // 4) enqueue 성공 → RECEIVED → QUEUED
-            long queuedAt = System.currentTimeMillis();
+
+            // 4) enqueue 성공 → RECEIVED → QUEUED+ queuedAt
 
             Map<String, Object> patch = new HashMap<>();
             patch.put("queuedAt", queuedAt);

--- a/worker/build.gradle
+++ b/worker/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     implementation platform('software.amazon.awssdk:bom:2.29.0')
     implementation 'software.amazon.awssdk:dynamodb'
+    implementation 'software.amazon.awssdk:eventbridge'
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/worker/src/main/java/com/teamA/async/worker/analytics/publisher/ParticipationEventBridgePublisher.java
+++ b/worker/src/main/java/com/teamA/async/worker/analytics/publisher/ParticipationEventBridgePublisher.java
@@ -1,0 +1,58 @@
+package com.teamA.async.worker.analytics.publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamA.async.worker.analytics.event.ParticipationProcessedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ParticipationEventBridgePublisher {
+
+    private final EventBridgeClient eventBridgeClient;
+    private final ObjectMapper objectMapper;
+
+    // 고정 규칙
+    private static final String SOURCE = "kr.ac.dongduk.worker";
+    private static final String DETAIL_TYPE = "ParticipationProcessed";
+
+    public void publish(ParticipationProcessedEvent payload) {
+        try {
+            String detailJson = objectMapper.writeValueAsString(payload);
+
+            PutEventsRequestEntry entry = PutEventsRequestEntry.builder()
+                    .source(SOURCE)
+                    .detailType(DETAIL_TYPE)
+                    .detail(detailJson)
+                    .build();
+
+            PutEventsResponse resp = eventBridgeClient.putEvents(
+                    PutEventsRequest.builder().entries(entry).build()
+            );
+
+            int failed = resp.failedEntryCount() == null ? 0 : resp.failedEntryCount();
+
+            // 운영 최소 로그 1줄: 실패 카운트
+            if (failed == 0) {
+                log.info("[EVENTBRIDGE] putEvents ok. requestId={} finalStatus={} resultCode={}",
+                        payload.requestId(), payload.finalStatus(), payload.resultCode());
+            } else {
+                // 실패 시 entry error까지 같이
+                log.warn("[EVENTBRIDGE] putEvents failedEntryCount={} requestId={} errors={}",
+                        failed,
+                        payload.requestId(),
+                        resp.entries());
+            }
+
+        } catch (Exception e) {
+            // 예외 전파 금지(Worker 흐름 끊기면 안 됨)
+            log.warn("[EVENTBRIDGE] putEvents exception ignored. requestId={}", payload.requestId(), e);
+        }
+    }
+}

--- a/worker/src/main/java/com/teamA/async/worker/config/AwsClientConfig.java
+++ b/worker/src/main/java/com/teamA/async/worker/config/AwsClientConfig.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 
 @Configuration
 public class AwsClientConfig {
@@ -36,4 +37,13 @@ public class AwsClientConfig {
                 )
                 .build();
     }
+
+    @Bean
+    public EventBridgeClient eventBridgeClient() {
+        return EventBridgeClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(ProfileCredentialsProvider.create(profile))
+                .build();
+    }
+
 }

--- a/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
+++ b/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
@@ -2,7 +2,12 @@ package com.teamA.async.worker.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teamA.async.common.domain.enums.EventType;
+import com.teamA.async.common.domain.enums.FailureClass;
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.enums.ResultCode;
 import com.teamA.async.common.messaging.ParticipationMessage;
+import com.teamA.async.worker.analytics.event.*;
+import com.teamA.async.worker.analytics.publisher.ParticipationEventBridgePublisher;
 import com.teamA.async.worker.ddb.EventCapacityRepository;
 import com.teamA.async.worker.ddb.RequestStateRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,24 +15,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.sqs.SqsClient;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
-import software.amazon.awssdk.services.sqs.model.Message;
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-/**
- * SQS 메시지를 소비하여 Request를 처리하는 Worker 진입점
- *
- * 요구사항(1~6) 반영 포인트
- * - 메시지 파싱 실패: NON-RETRYABLE → 즉시 ack(delete)
- * - 상태 선점: QUEUED → PROCESSING 조건부 업데이트로 단일 Worker만 처리
- * - FIRST_COME만 capacity 로직 진입
- * - capacityRemaining > 0 일 때만 원자적 감소
- * - 감소 성공/실패에 따라 PROCESSING → SUCCEEDED / REJECTED_CAPACITY 조건부 전이
- * - 이미 최종 상태(또는 선점 실패)면 capacity 로직 실행 없이 즉시 ack(delete)로 멱등 보장
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -37,99 +32,307 @@ public class SqsMessageConsumer {
     private final ObjectMapper objectMapper;
     private final RequestStateRepository requestStateRepository;
     private final EventCapacityRepository eventCapacityRepository;
+    private final ParticipationEventBridgePublisher publisher;
 
-    /**
-     * worker/application.yml
-     * sqs:
-     *   queue-url: ...
-     */
     @Value("${sqs.queue-url}")
     private String queueUrl;
 
+    // 나중에 yml + @Value로 바꾸기
+    private static final int SCHEMA_VERSION = 1;
+    private static final String ENV = "dev";
+
+    // DLQ consumer 분리 시 true로 두고 재사용 가능
+    private static final boolean IS_DLQ = false;
+
+    // (옵션) messageAttributes에서 복구할 때 사용할 키(ingest가 messageAttributes로도 넣는다면)
+    private static final String MA_REQUEST_ID = "requestId";
+    private static final String MA_EVENT_ID   = "eventId";
+    private static final String MA_USER_ID    = "userId";
+    private static final String MA_EVENT_TYPE = "eventType";
+    private static final String MA_QUEUED_AT  = "queuedAt";
+
     @Scheduled(fixedDelay = 3000)
     public void pollMessages() {
-        ReceiveMessageRequest request = ReceiveMessageRequest.builder()
+        ReceiveMessageRequest req = ReceiveMessageRequest.builder()
                 .queueUrl(queueUrl)
                 .waitTimeSeconds(20)
                 .maxNumberOfMessages(5)
+                .attributeNamesWithStrings("ApproximateReceiveCount")                .messageAttributeNames("All")
                 .build();
 
-        List<Message> messages = sqsClient.receiveMessage(request).messages();
-
-        for (Message message : messages) {
-            handleMessage(message);
+        List<Message> messages = sqsClient.receiveMessage(req).messages();
+        for (Message m : messages) {
+            handleMessage(m);
         }
     }
 
     private void handleMessage(Message message) {
+        final int attempt = parseAttempt(message);
+        final long startedAt = System.currentTimeMillis();
+
         ParticipationMessage payload;
 
-        // 0) 메시지 역직렬화
+        // 1) body 파싱 시도
         try {
             payload = objectMapper.readValue(message.body(), ParticipationMessage.class);
-            log.info(
-                    "[PARSED OK] requestId={}, eventId={}, eventType={}",
-                    payload.requestId(),
-                    payload.eventId(),
-                    payload.eventType()
-            );
-        } catch (Exception e) {
-            log.error("[NON-RETRYABLE] invalid message body={}", message.body(), e);
-            deleteMessage(message);
-            return;
-        }
+            log.info("[PARSED OK/BODY] requestId={}, eventId={}, userId={}, eventType={}, queuedAt={}, attempt={}",
+                    payload.requestId(), payload.eventId(), payload.userId(), payload.eventType(), payload.queuedAt(), attempt);
 
-        // 1) QUEUED → PROCESSING 선점
-        boolean acquired = requestStateRepository.tryAcquireProcessing(payload.requestId());
-
-        if (!acquired) {
-            // 2) 선점 실패 → 멱등 방어
-            requestStateRepository.getCurrentStatus(payload.requestId())
-                    .ifPresentOrElse(
-                            status -> log.info("[SKIP] requestId={} already status={}", payload.requestId(), status),
-                            () -> log.info("[SKIP] requestId={} no item found", payload.requestId())
-                    );
-
-            deleteMessage(message);
-            return;
-        }
-
-        // 3) 단일 Worker만 진입
-        try {
-            // ✅ FIRST_COME 이벤트만 capacity 로직 수행 (enum 비교)
-            if (payload.eventType() == EventType.FIRST_COME) {
-
-                boolean gotSlot = eventCapacityRepository.tryDecrement(payload.eventId());
-
-                if (gotSlot) {
-                    boolean ok = requestStateRepository.markSucceeded(payload.requestId());
-                    log.info("[FINAL] requestId={} -> SUCCEEDED (updated={})", payload.requestId(), ok);
-                } else {
-                    boolean ok = requestStateRepository.markRejectedCapacity(payload.requestId());
-                    log.info("[FINAL] requestId={} -> REJECTED_CAPACITY (updated={})", payload.requestId(), ok);
-                }
-
+        } catch (Exception bodyEx) {
+            // 2) body가 깨졌으면 messageAttributes로 복구 시도(선택)
+            try {
+                payload = buildPayloadFromAttributes(message.messageAttributes());
+                log.warn("[PARSED OK/ATTR] body invalid -> recovered. requestId={}, eventId={}, userId={}, eventType={}, queuedAt={}, attempt={}",
+                        payload.requestId(), payload.eventId(), payload.userId(), payload.eventType(), payload.queuedAt(), attempt);
+            } catch (Exception attrEx) {
+                // requestId조차 없으면 전이 불가 -> ack
+                log.warn("[NON-RETRYABLE] invalid body and cannot recover attrs. attempt={} body={}",
+                        attempt, safeBody(message), bodyEx);
                 deleteMessage(message);
                 return;
             }
 
-            // G0 범위: FIRST_COME 외 이벤트는 성공 처리
-            boolean ok = requestStateRepository.markSucceeded(payload.requestId());
-            log.info("[FINAL] requestId={} -> SUCCEEDED (non-FIRST_COME, updated={})", payload.requestId(), ok);
+            // QUEUED -> PROCESSING 선점 먼저
+            boolean acquired = requestStateRepository.tryAcquireProcessing(payload.requestId(), startedAt);
+            if (!acquired) {
+                Optional<String> cur = requestStateRepository.getCurrentStatus(payload.requestId());
+                log.info("[SKIP/INVALID] requestId={} already status={}, attempt={}",
+                        payload.requestId(), cur.orElse("UNKNOWN"), attempt);
+                deleteMessage(message);
+                return;
+            }
+
+            // 그 다음에 PROCESSING -> FAILED_FINAL
+            long finishedAt = System.currentTimeMillis();
+            boolean updated = requestStateRepository.markFailedFinal(
+                    payload.requestId(),
+                    finishedAt,
+                    ResultCode.FAILED_INGEST_ENQUEUE, // 아래 2)에서 enum 추천
+                    FailureClass.NON_RETRYABLE,
+                    "INVALID_MESSAGE_BODY",
+                    "Body JSON parse failed; recovered from messageAttributes"
+            );
+
+            publisher.publish(buildEvent(
+                    payload, attempt, IS_DLQ,
+                    startedAt, finishedAt,
+                    RequestStatus.FAILED_FINAL,
+                    ResultCode.FAILED_INGEST_ENQUEUE,
+                    new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "INVALID_MESSAGE_BODY", "Body JSON parse failed")
+            ));
+
+            log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (INVALID_MESSAGE_BODY)",
+                    payload.requestId(), updated, attempt);
+
+            deleteMessage(message);
+            return;
+        }
+
+        // 3) QUEUED -> PROCESSING 선점
+        boolean acquired = requestStateRepository.tryAcquireProcessing(payload.requestId(), startedAt);
+        if (!acquired) {
+            Optional<String> cur = requestStateRepository.getCurrentStatus(payload.requestId());
+
+            if (cur.isEmpty()) {
+                // RequestItem 없음 = 유령 메시지 -> ack ✅
+                log.info("[SKIP] requestId={} no item found, attempt={} (ghost msg -> ack)", payload.requestId(), attempt);
+                deleteMessage(message);
+                return;
+            }
+
+            String status = cur.get();
+            switch (status) {
+                case "RECEIVED":
+                case "QUEUED":
+                    // 레이스/경합 -> ack ❌ (재시도에서 다시 잡도록)
+                    log.info("[SKIP] requestId={} status={} attempt={} (race/contend -> no-ack)", payload.requestId(), status, attempt);
+                    return;
+
+                case "PROCESSING":
+                case "SUCCEEDED":
+                case "REJECTED":
+                case "FAILED_FINAL":
+                default:
+                    // 이미 처리 중/처리 완료/알 수 없음 -> 중복 메시지로 보고 ack ✅
+                    log.info("[SKIP] requestId={} status={} attempt={} (dup -> ack)", payload.requestId(), status, attempt);
+                    deleteMessage(message);
+                    return;
+            }
+        }
+
+
+        // 4) 단일 Worker만 진입
+        try {
+            final long finishedAt;
+            final RequestStatus finalStatus;
+            final ResultCode resultCode;
+
+            if (payload.eventType() == EventType.FIRST_COME) {
+                boolean gotSlot = eventCapacityRepository.tryDecrement(payload.eventId());
+                finishedAt = System.currentTimeMillis();
+
+                if (gotSlot) {
+                    boolean ok = requestStateRepository.markSucceeded(payload.requestId(), finishedAt);
+                    log.info("[FINAL] requestId={} -> SUCCEEDED (updated={}) attempt={}", payload.requestId(), ok, attempt);
+                    finalStatus = RequestStatus.SUCCEEDED;
+                    resultCode = ResultCode.SUCCESS;
+                } else {
+                    boolean ok = requestStateRepository.markRejectedCapacity(payload.requestId(), finishedAt);
+                    log.info("[FINAL] requestId={} -> REJECTED_CAPACITY (updated={}) attempt={}", payload.requestId(), ok, attempt);
+                    finalStatus = RequestStatus.REJECTED;
+                    resultCode = ResultCode.REJECTED_CAPACITY;
+                }
+            } else {
+                finishedAt = System.currentTimeMillis();
+                boolean ok = requestStateRepository.markSucceeded(payload.requestId(), finishedAt);
+                log.info("[FINAL] requestId={} -> SUCCEEDED (non-FIRST_COME, updated={}) attempt={}", payload.requestId(), ok, attempt);
+                finalStatus = RequestStatus.SUCCEEDED;
+                resultCode = ResultCode.SUCCESS;
+            }
+
+            publisher.publish(buildEvent(payload, attempt, IS_DLQ, startedAt, finishedAt, finalStatus, resultCode, null));
             deleteMessage(message);
 
         } catch (Exception e) {
-            // 예외 발생 시 delete하지 않음 → 재시도 → DLQ
-            log.error("[RETRYABLE] worker exception requestId={}", payload.requestId(), e);
+            FailureClass cls = classifyFailure(e);
+
+            if (cls == FailureClass.NON_RETRYABLE) {
+                long finishedAt = System.currentTimeMillis();
+
+                boolean ok = requestStateRepository.markFailedFinal(
+                        payload.requestId(),
+                        finishedAt,
+                        ResultCode.FAILED_INGEST_ENQUEUE, // 권장: FAILED_WORKER_EXCEPTION 같은 enum 추가
+                        FailureClass.NON_RETRYABLE,
+                        "WORKER_NON_RETRYABLE",
+                        e.getMessage()
+                );
+
+                publisher.publish(buildEvent(
+                        payload, attempt, IS_DLQ,
+                        startedAt, finishedAt,
+                        RequestStatus.FAILED_FINAL,
+                        ResultCode.FAILED_INGEST_ENQUEUE,
+                        new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "WORKER_NON_RETRYABLE", e.getMessage())
+                ));
+
+                log.warn("[NON-RETRYABLE] requestId={} -> FAILED_FINAL updated={} attempt={}", payload.requestId(), ok, attempt, e);
+                deleteMessage(message);
+                return;
+            }
+
+            // Retryable: ack 하지 않음 -> 재시도 -> DLQ
+            log.error("[RETRYABLE] worker exception requestId={} attempt={}", payload.requestId(), attempt, e);
         }
     }
 
-    private void deleteMessage(Message message) {
-        DeleteMessageRequest deleteRequest = DeleteMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .receiptHandle(message.receiptHandle())
-                .build();
+    // ---------------- helpers ----------------
 
-        sqsClient.deleteMessage(deleteRequest);
+    private ParticipationMessage buildPayloadFromAttributes(Map<String, MessageAttributeValue> attrs) {
+        String requestId = getAttrString(attrs, MA_REQUEST_ID);
+        String eventId   = getAttrString(attrs, MA_EVENT_ID);
+        String userId    = getAttrString(attrs, MA_USER_ID);
+        String eventTypeStr = getAttrString(attrs, MA_EVENT_TYPE);
+        String queuedAtStr  = getAttrString(attrs, MA_QUEUED_AT);
+
+        if (requestId == null || requestId.isBlank()) throw new IllegalArgumentException("missing requestId attr");
+        if (eventId == null || eventId.isBlank()) throw new IllegalArgumentException("missing eventId attr");
+        if (userId == null || userId.isBlank()) throw new IllegalArgumentException("missing userId attr");
+        if (eventTypeStr == null || eventTypeStr.isBlank()) throw new IllegalArgumentException("missing eventType attr");
+        if (queuedAtStr == null || queuedAtStr.isBlank()) throw new IllegalArgumentException("missing queuedAt attr");
+
+        EventType eventType = EventType.valueOf(eventTypeStr);
+        long queuedAt = Long.parseLong(queuedAtStr);
+
+        // ✅ record 시그니처 순서: requestId, eventId, userId, queuedAt, eventType
+        return new ParticipationMessage(requestId, eventId, userId, queuedAt, eventType);
+    }
+
+    private String getAttrString(Map<String, MessageAttributeValue> attrs, String key) {
+        MessageAttributeValue v = attrs.get(key);
+        return v == null ? null : v.stringValue();
+    }
+
+    private int parseAttempt(Message message) {
+        try {
+            String rc = message.attributesAsStrings().get("ApproximateReceiveCount");
+            if (rc == null) return 1;
+            return Math.max(1, Integer.parseInt(rc));
+        } catch (Exception ignore) {
+            return 1;
+        }
+    }
+
+    private String safeBody(Message message) {
+        try {
+            String b = message.body();
+            if (b == null) return "null";
+            return b.length() <= 500 ? b : b.substring(0, 500) + "...";
+        } catch (Exception e) {
+            return "unavailable";
+        }
+    }
+
+    private FailureClass classifyFailure(Exception e) {
+        if (e instanceof IllegalArgumentException) return FailureClass.NON_RETRYABLE;
+
+        if (e instanceof SqsException se) {
+            int sc = se.statusCode();
+            if (sc >= 400 && sc < 500) return FailureClass.NON_RETRYABLE;
+        }
+
+        if (e instanceof DynamoDbException de) {
+            int sc = de.statusCode();
+            if (sc >= 400 && sc < 500) return FailureClass.NON_RETRYABLE;
+        }
+
+        return FailureClass.RETRYABLE;
+    }
+
+    private ParticipationProcessedEvent buildEvent(
+            ParticipationMessage payload,
+            int attempt,
+            boolean isDlq,
+            long startedAt,
+            long finishedAt,
+            RequestStatus finalStatus,
+            ResultCode resultCode,
+            ParticipationProcessedFailure failureOrNull
+    ) {
+        ParticipationProcessedTimestamps ts =
+                new ParticipationProcessedTimestamps(payload.queuedAt(), startedAt, finishedAt);
+
+        ParticipationProcessedDelivery delivery =
+                new ParticipationProcessedDelivery(attempt, isDlq);
+
+        String workerId = Optional.ofNullable(System.getenv("HOSTNAME")).orElse("worker-local");
+        ParticipationProcessedMeta meta = new ParticipationProcessedMeta(workerId);
+
+        if (failureOrNull == null) {
+            return ParticipationProcessedEvent.noFailure(
+                    SCHEMA_VERSION, ENV,
+                    payload.eventId(), payload.requestId(), payload.userId(),
+                    payload.eventType(), finalStatus, resultCode,
+                    ts, delivery, meta
+            );
+        }
+
+        return new ParticipationProcessedEvent(
+                SCHEMA_VERSION, ENV,
+                payload.eventId(), payload.requestId(), payload.userId(),
+                payload.eventType(), finalStatus, resultCode,
+                ts, delivery, failureOrNull, meta
+        );
+    }
+
+    private void deleteMessage(Message message) {
+        try {
+            sqsClient.deleteMessage(DeleteMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .receiptHandle(message.receiptHandle())
+                    .build());
+        } catch (Exception e) {
+            log.warn("[ACK FAIL] deleteMessage failed", e);
+        }
     }
 }

--- a/worker/src/main/java/com/teamA/async/worker/ddb/RequestStateRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/RequestStateRepository.java
@@ -1,12 +1,14 @@
 package com.teamA.async.worker.ddb;
 
 import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import com.teamA.async.common.domain.enums.FailureClass;
+import com.teamA.async.common.domain.enums.ResultCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -16,26 +18,29 @@ import java.util.Optional;
 public class RequestStateRepository {
 
     private final DynamoDbClient dynamoDbClient;
-    private static final String TABLE_NAME = "AsyncEventTable";
+
+    @Value("${ddb.table-name}")
+    private String tableName;
+
+    private static final String ATTR_PK = "PK";
+    private static final String ATTR_SK = "SK";
 
     /**
-     * QUEUED → PROCESSING 선점
+     * QUEUED -> PROCESSING 선점
+     * - Condition: status = QUEUED
+     * - Update: status = PROCESSING, startedAt = startedAtMillis
      */
-    public boolean tryAcquireProcessing(String requestId) {
+    public boolean tryAcquireProcessing(String requestId, long startedAtMillis) {
         Map<String, AttributeValue> key = Map.of(
-                "PK", AttributeValue.builder()
-                        .s(DdbKeyFactory.requestPk(requestId))
-                        .build(),
-                "SK", AttributeValue.builder()
-                        .s(DdbKeyFactory.metaSk())
-                        .build()
+                ATTR_PK, AttributeValue.builder().s(DdbKeyFactory.requestPk(requestId)).build(),
+                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.metaSk()).build()
         );
 
         UpdateItemRequest req = UpdateItemRequest.builder()
-                .tableName(TABLE_NAME)
+                .tableName(tableName)
                 .key(key)
                 .conditionExpression("#status = :queued")
-                .updateExpression("SET #status = :processing, #startedAt = :now")
+                .updateExpression("SET #status = :processing, #startedAt = :startedAt")
                 .expressionAttributeNames(Map.of(
                         "#status", "status",
                         "#startedAt", "startedAt"
@@ -43,9 +48,7 @@ public class RequestStateRepository {
                 .expressionAttributeValues(Map.of(
                         ":queued", AttributeValue.builder().s("QUEUED").build(),
                         ":processing", AttributeValue.builder().s("PROCESSING").build(),
-                        ":now", AttributeValue.builder()
-                                .n(String.valueOf(Instant.now().toEpochMilli()))
-                                .build()
+                        ":startedAt", AttributeValue.builder().n(String.valueOf(startedAtMillis)).build()
                 ))
                 .build();
 
@@ -57,41 +60,84 @@ public class RequestStateRepository {
         }
     }
 
-    public boolean markSucceeded(String requestId) {
+    /**
+     * PROCESSING -> SUCCEEDED
+     */
+    public boolean markSucceeded(String requestId, long finishedAtMillis) {
         return updateFinalStatus(
                 requestId,
                 "SUCCEEDED",
                 "SUCCESS",
-                "SUCCESS",
+                ResultCode.SUCCESS,
+                null,
+                finishedAtMillis,
+                null,
                 null
         );
     }
 
-    public boolean markRejectedCapacity(String requestId) {
+    /**
+     * PROCESSING -> REJECTED (capacity)
+     */
+    public boolean markRejectedCapacity(String requestId, long finishedAtMillis) {
         return updateFinalStatus(
                 requestId,
                 "REJECTED",
                 "REJECTED",
-                "REJECTED_CAPACITY",
-                "NON_RETRYABLE"
+                ResultCode.REJECTED_CAPACITY,
+                null, // ✅ REJECT는 failure로 보지 않는 편(분석 일관성)
+                finishedAtMillis,
+                null,
+                null
         );
     }
 
+    /**
+     * PROCESSING -> FAILED_FINAL
+     * - 실패는 분석을 위해 errorCode/errorMessage도 남긴다(선택)
+     */
+    public boolean markFailedFinal(
+            String requestId,
+            long finishedAtMillis,
+            ResultCode resultCode,
+            FailureClass failureClass,
+            String errorCode,
+            String errorMessage
+    ) {
+        return updateFinalStatus(
+                requestId,
+                "FAILED_FINAL",
+                "FAILED",
+                resultCode,
+                failureClass,
+                finishedAtMillis,
+                errorCode,
+                errorMessage
+        );
+    }
+
+    /**
+     * 최종 상태 공통 업데이트
+     * - Condition: status = PROCESSING
+     * - Update: status/finishedAt/uiResult/resultCode(+ failureClass?) (+ errorCode/errorMessage?)
+     */
     private boolean updateFinalStatus(
             String requestId,
             String targetStatus,
             String uiResult,
-            String resultCode,
-            String failureClass
+            ResultCode resultCode,
+            FailureClass failureClass,
+            long finishedAtMillis,
+            String errorCode,
+            String errorMessage
     ) {
         Map<String, AttributeValue> key = Map.of(
-                "PK", AttributeValue.builder()
-                        .s(DdbKeyFactory.requestPk(requestId))
-                        .build(),
-                "SK", AttributeValue.builder()
-                        .s(DdbKeyFactory.metaSk())
-                        .build()
+                ATTR_PK, AttributeValue.builder().s(DdbKeyFactory.requestPk(requestId)).build(),
+                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.metaSk()).build()
         );
+
+        // DDB 안전: 너무 긴 메시지는 잘라서 저장(아이템 사이즈/로그 폭주 방지)
+        String safeErrorMessage = truncate(errorMessage, 500);
 
         Map<String, String> names = new HashMap<>();
         Map<String, AttributeValue> values = new HashMap<>();
@@ -103,23 +149,33 @@ public class RequestStateRepository {
 
         values.put(":processing", AttributeValue.builder().s("PROCESSING").build());
         values.put(":target", AttributeValue.builder().s(targetStatus).build());
+        values.put(":finishedAt", AttributeValue.builder().n(String.valueOf(finishedAtMillis)).build());
         values.put(":uiResult", AttributeValue.builder().s(uiResult).build());
-        values.put(":resultCode", AttributeValue.builder().s(resultCode).build());
-        values.put(":now", AttributeValue.builder()
-                .n(String.valueOf(Instant.now().toEpochMilli()))
-                .build());
+        values.put(":resultCode", AttributeValue.builder().s(resultCode.name()).build());
 
         String updateExpr =
-                "SET #status = :target, #finishedAt = :now, #uiResult = :uiResult, #resultCode = :resultCode";
+                "SET #status = :target, #finishedAt = :finishedAt, #uiResult = :uiResult, #resultCode = :resultCode";
 
         if (failureClass != null) {
             names.put("#failureClass", "failureClass");
-            values.put(":failureClass", AttributeValue.builder().s(failureClass).build());
+            values.put(":failureClass", AttributeValue.builder().s(failureClass.name()).build());
             updateExpr += ", #failureClass = :failureClass";
         }
 
+        if (errorCode != null && !errorCode.isBlank()) {
+            names.put("#errorCode", "errorCode");
+            values.put(":errorCode", AttributeValue.builder().s(errorCode).build());
+            updateExpr += ", #errorCode = :errorCode";
+        }
+
+        if (safeErrorMessage != null && !safeErrorMessage.isBlank()) {
+            names.put("#errorMessage", "errorMessage");
+            values.put(":errorMessage", AttributeValue.builder().s(safeErrorMessage).build());
+            updateExpr += ", #errorMessage = :errorMessage";
+        }
+
         UpdateItemRequest req = UpdateItemRequest.builder()
-                .tableName(TABLE_NAME)
+                .tableName(tableName)
                 .key(key)
                 .conditionExpression("#status = :processing")
                 .updateExpression(updateExpr)
@@ -135,30 +191,34 @@ public class RequestStateRepository {
         }
     }
 
+    /**
+     * 상태 조회 (선점 실패 시 로깅/분기용)
+     */
     public Optional<String> getCurrentStatus(String requestId) {
         Map<String, AttributeValue> key = Map.of(
-                "PK", AttributeValue.builder()
-                        .s(DdbKeyFactory.requestPk(requestId))
-                        .build(),
-                "SK", AttributeValue.builder()
-                        .s(DdbKeyFactory.metaSk())
-                        .build()
+                ATTR_PK, AttributeValue.builder().s(DdbKeyFactory.requestPk(requestId)).build(),
+                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.metaSk()).build()
         );
 
         GetItemRequest request = GetItemRequest.builder()
-                .tableName(TABLE_NAME)
+                .tableName(tableName)
                 .key(key)
                 .projectionExpression("#status")
                 .expressionAttributeNames(Map.of("#status", "status"))
                 .consistentRead(true)
                 .build();
 
-        Map<String, AttributeValue> item =
-                dynamoDbClient.getItem(request).item();
+        Map<String, AttributeValue> item = dynamoDbClient.getItem(request).item();
 
         if (item == null || !item.containsKey("status")) {
             return Optional.empty();
         }
-        return Optional.of(item.get("status").s());
+        return Optional.ofNullable(item.get("status")).map(AttributeValue::s);
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null) return null;
+        if (s.length() <= maxLen) return s;
+        return s.substring(0, maxLen);
     }
 }

--- a/worker/src/main/resources/application.yml
+++ b/worker/src/main/resources/application.yml
@@ -3,9 +3,16 @@ server:
 
 aws:
   region: ap-northeast-2
-  profile: hyeyun
+  profile: wish
 ddb:
   table-name: AsyncEventTable
 
 sqs:
   queue-url: ${SQS_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/590807098068/AsyncEventMainQueue}
+
+analytics:
+  event:
+    source: kr.ac.dongduk.worker
+    detail-type: ParticipationProcessed
+
+


### PR DESCRIPTION
related to #39
#10

## 📌 작업 내용
G1 관측 가능성(Observability) 확보를 위해
Worker가 처리 완료한 요청 1건의 결과를 ParticipationProcessed 이벤트로 EventBridge에 발행하고,
Firehose를 통해 S3 Data Lake에 NDJSON 1줄로 적재되도록 연결합니다.

본 PR은 Step3(발행 연결 단계) 에 해당하며,
스키마 정의(Step2)는 변경하지 않습니다.

## 🔍 작업 상세
- [x] Worker → EventBridge 발행 로직 구현
- 처리 완료 직후 putEvents 호출
- 실패 시에도 Worker 본 처리 흐름 유지 (try/catch)
- [x] 타임스탬프 기준 고정
- queuedAt: SQS 메시지 계승
- startedAt: Worker 처리 시작 시각
- finishedAt: 최종 상태 결정 및 DynamoDB 업데이트 직후
- [x] ParticipationProcessedEvent payload 구성
- 필수 필드 누락 없음
- [x] 발행 결과 최소 로그 추가
- putEvents 성공 여부 확인 로그

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- Firehose를 통해 S3 Data Lake 적재 확인
<img width="704" height="541" alt="image" src="https://github.com/user-attachments/assets/b3bb2842-dc43-4364-a5e0-4dbb36e867e3" />
<br>

<img width="572" height="139" alt="image" src="https://github.com/user-attachments/assets/078b29a8-7eba-4800-90d0-0ee74c541f49" />
<br>

putEvents 성공 여부 확인 로그
<img width="818" height="115" alt="image" src="https://github.com/user-attachments/assets/d4f664ec-83f5-41f7-b177-93098acd37d1" />


## 🗨 기타 참고 사항
- 이슈 번호: #10 , #39 
#10 에서 못한 이슈들도 완료
