### PR TITLE
feat/g1-LoadTest

### DIFF
--- a/k6/g1_spike_participation.js
+++ b/k6/g1_spike_participation.js
@@ -1,0 +1,109 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+/**
+ * =========================
+ * 환경 변수
+ * =========================
+ */
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const EVENT_ID = __ENV.EVENT_ID || "EVT-009";
+const VUS = Number(__ENV.VUS || 2000);
+const DURATION = __ENV.DURATION || "90s";
+
+/**
+ * =========================
+ * G1 스파이크 시나리오
+ * =========================
+ * - 빠른 유입
+ * - 일정 시간 유지
+ * - Worker가 처리율 유지하는지 관찰
+ */
+export const options = {
+    scenarios: {
+        spike: {
+            executor: "ramping-vus",
+            startVUs: 0,
+            stages: [
+                { duration: "10s", target: VUS },     // 급격한 증가
+                { duration: DURATION, target: VUS },  // 유지
+                { duration: "10s", target: 0 },       // 급격한 감소
+            ],
+            gracefulRampDown: "30s",
+        },
+    },
+    thresholds: {
+        // ✅ G1에서는 “죽지 않는지”만 본다
+        http_req_failed: ["rate<0.01"],
+    },
+};
+
+/**
+ * =========================
+ * 유틸
+ * =========================
+ */
+function randomUserId(vu) {
+    return `user-g1-${vu}-${Math.random().toString(36).substring(2, 10)}`;
+}
+
+/**
+ * =========================
+ * VU별 토큰 캐시
+ * =========================
+ */
+let token;
+
+/**
+ * =========================
+ * VU 실행
+ * =========================
+ */
+export default function () {
+    /**
+     * 1️⃣ VU별 최초 1회 로그인
+     */
+    if (!token) {
+        const userId = randomUserId(__VU);
+
+        const loginRes = http.post(
+            `${BASE_URL}/auth/login`,
+            JSON.stringify({ userId }),
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+
+        check(loginRes, {
+            "login status 200": (r) => r.status === 200,
+            "has accessToken": (r) => r.json("accessToken") !== undefined,
+        });
+
+        token = loginRes.json("accessToken");
+    }
+
+    /**
+     * 2️⃣ 참여 요청 (비동기 enqueue)
+     */
+    const res = http.post(
+        `${BASE_URL}/events/${EVENT_ID}/participations`,
+        null,
+        {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
+
+    check(res, {
+        "status is 202": (r) => r.status === 202,
+        "has requestId": (r) => r.json("requestId") !== undefined,
+    });
+
+    /**
+     * Worker 관찰을 위한 완급 조절
+     */
+    sleep(0.1);
+}


### PR DESCRIPTION
related to #46

## 📌 작업 내용
- G1 단계 부하 테스트 수행을 위한 k6 스파이크 테스트 구성 및 실행
- Worker ON 상태에서 큐 적재 → 처리 → 회복 흐름 검증
- G1 부하 테스트 결과 문서화 및 검증 기준 정리

## 🔍 작업 상세
- [x] G1 부하 테스트 목적 정의  
  - 트래픽 급증 시 Queue가 요청을 흡수하고  
    Worker가 처리율을 유지하며 점진적으로 소화하는지 검증
  - 단순 적재(G0)와 달리 처리 흐름·지연·회복 특성 관찰

- [x] G1 전용 k6 스파이크 스크립트 작성 및 검증  
  - ramping-vus 기반 스파이크 시나리오 구성
  - VU별 userId 분리 및 VU별 1회 로그인 토큰 캐싱
  - 모든 요청에 대해 202 Accepted + requestId 반환 확인

- [x] Worker ON 상태에서 부하 테스트 수행  
  - ingest-api / worker 동시 기동
  - QueueDepth 급증 → Worker 처리 시작 후 점진적 감소 확인
  - NumberOfMessagesDeleted 지속 증가 확인
  - DLQ 유입 없음 확인

- [x] k6 threshold 기준 재조정  
  - 초기 p95 응답시간 threshold(<500ms)로 인한 실패 확인
  - G1 목적에 맞게 p95 기준 제거, 실패율(http_req_failed)만 검증
  - 시스템 에러가 아닌 “지연(degrade)” 현상임을 확인

- [x] Athena 기반 사후 분석 수행  
  - queuedAt 기준 유입량 = k6 요청 수 일치 확인
  - finishedAt 기준 처리량 = QueueDepth 회복 결과와 일치 확인
  - p95 Queue Delay / E2E Delay 산출
  - 음수 지연, timestamp null 0건 확인

- [x] requestId 단위 최종 상태 검증  
  - SUCCEEDED / REJECTED 최종 상태 도달 확인
  - FAILED_FINAL 발생 없음 확인 (정상 시나리오)

- [x] G1 부하 테스트 체크리스트 및 결과 문서 정리  
  - 검증 포인트(API / Queue / Worker / 지연 / Athena / DLQ) 명문화
  - G0 vs G1 차이점 정리
  - `docs/g1-load-test.md` 결과 정리

## 🧪 테스트 결과
-k6 테스트 에러x
<img width="2337" height="954" alt="image" src="https://github.com/user-attachments/assets/48be195f-7741-4edc-bdfb-6b924ec00597" />

- CloudWatch QueueDepth 점진적 감소 확인됨
<img width="2732" height="942" alt="image" src="https://github.com/user-attachments/assets/5bb2178d-c2ea-44e3-923e-2e8bda8694fb" />

- CloudWatch NumberOfMessagesDeleted 지속적 유입 확인됨
<img width="2759" height="921" alt="image" src="https://github.com/user-attachments/assets/bbdda293-4b9a-4ca2-b318-1f1ead36708c" />


## 🗨 기타 참고 사항
- 이슈 번호: `#46`

