### PR TITLE
chore: Worker AWS 인증 fallback 및 ECS 컨테이너화 완료

### DIFF
--- a/ingest-api/Dockerfile
+++ b/ingest-api/Dockerfile
@@ -1,0 +1,8 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+# 이미 만들어진 jar만 복사
+COPY build/libs/ingest-api.jar /app/app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java","-XX:MaxRAMPercentage=75.0","-jar","/app/app.jar"]

--- a/ingest-api/src/main/resources/application-ecs.yml
+++ b/ingest-api/src/main/resources/application-ecs.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8080
+
+aws:
+  region: ${AWS_REGION:ap-northeast-2}
+
+ddb:
+  table-name: ${DDB_TABLE_NAME:AsyncEventTable}
+
+sqs:
+  queue-url: ${SQS_QUEUE_URL}
+
+logging:
+  level:
+    root: INFO

--- a/ingest-api/src/main/resources/application.yml
+++ b/ingest-api/src/main/resources/application.yml
@@ -8,7 +8,7 @@ management:
         include: health,info
 aws:
   region: ${AWS_REGION:ap-northeast-2}
-  profile: admin
+
   dynamodb:
     table-name: ${DDB_TABLE_NAME:AsyncEventTable}
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY build/libs/worker.jar /app/app.jar
+
+EXPOSE 8081
+ENTRYPOINT ["java","-XX:MaxRAMPercentage=75.0","-jar","/app/app.jar"]

--- a/worker/src/main/java/com/teamA/async/worker/config/AwsClientConfig.java
+++ b/worker/src/main/java/com/teamA/async/worker/config/AwsClientConfig.java
@@ -3,28 +3,37 @@ package com.teamA.async.worker.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
 
 @Configuration
 public class AwsClientConfig {
 
-    @Value("${aws.region}")
+    @Value("${aws.region:ap-northeast-2}")
     private String region;
 
-    @Value("${aws.profile}")
+    // ✅ profile은 ECS에서 없을 수 있으므로 optional로
+    @Value("${aws.profile:}")
     private String profile;
+
+    private AwsCredentialsProvider credentialsProvider() {
+        if (profile != null && !profile.isBlank()) {
+            return ProfileCredentialsProvider.create(profile);
+        }
+        // ✅ ECS(Task Role), EC2(instance profile), 환경변수 등 자동 탐색
+        return DefaultCredentialsProvider.create();
+    }
 
     @Bean
     public SqsClient sqsClient() {
         return SqsClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(
-                        ProfileCredentialsProvider.create(profile)
-                )
+                .credentialsProvider(credentialsProvider())
                 .build();
     }
 
@@ -32,9 +41,7 @@ public class AwsClientConfig {
     public DynamoDbClient dynamoDbClient() {
         return DynamoDbClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(
-                        ProfileCredentialsProvider.create(profile)
-                )
+                .credentialsProvider(credentialsProvider())
                 .build();
     }
 
@@ -42,8 +49,7 @@ public class AwsClientConfig {
     public EventBridgeClient eventBridgeClient() {
         return EventBridgeClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(ProfileCredentialsProvider.create(profile))
+                .credentialsProvider(credentialsProvider())
                 .build();
     }
-
 }

--- a/worker/src/main/resources/application-ecs.yml
+++ b/worker/src/main/resources/application-ecs.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8081
+
+aws:
+  region: ${AWS_REGION:ap-northeast-2}
+
+ddb:
+  table-name: ${DDB_TABLE_NAME:AsyncEventTable}
+
+sqs:
+  queue-url: ${SQS_QUEUE_URL}
+
+analytics:
+  event:
+    source: ${ANALYTICS_SOURCE:kr.ac.dongduk.worker}
+    detail-type: ${ANALYTICS_DETAIL_TYPE:ParticipationProcessed}

--- a/worker/src/main/resources/application.yml
+++ b/worker/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 aws:
   region: ap-northeast-2
-  profile: admin
+
 ddb:
   table-name: AsyncEventTable
 


### PR DESCRIPTION
related to #49

## 📌 작업 내용
G2 단계 진입을 위해 기존 G1 로직을 변경하지 않고  
Ingest / Worker 실행 환경을 ECS 기반으로 전환한다.

본 PR은 **컨테이너화 및 AWS 인증 방식 정비**까지만 포함하며,  
비즈니스 로직 및 처리 흐름에는 변경이 없다.


## 🔍 작업 상세
- [x] ingest-api / worker 런타임 전용 Dockerfile 구성
- [x] ECS 환경용 `application-ecs.yml` 추가
  - aws.profile 제거
  - 모든 설정을 환경변수 기반으로 전환
- [x] Worker AWS Client 설정 수정
  - profile 존재 시: ProfileCredentialsProvider
  - profile 미존재 시: DefaultCredentialsProvider (ECS Task Role 대응)
- [x] 로컬 컨테이너 부팅 확인
- [x] ECR Repository 생성 (`ingest`, `worker`)
- [x] 이미지 태그 규칙 `<git-sha>` 고정 및 push 완료

## 🧪 테스트 결과
<img width="640" height="410" alt="image" src="https://github.com/user-attachments/assets/41691f4d-ddda-473a-b228-089484692566" />


## 🗨 기타 참고 사항
- 이슈 번호: #49 
- 로직 변경 ❌
- 처리 방식 변경 ❌
- Auto Scaling 미적용
- ECS Task Definition / Service 생성은 **Step2 이후**

## 📦 배포 아티팩트
- Ingest  
  `590807098068.dkr.ecr.ap-northeast-2.amazonaws.com/ingest:<git-sha>`
- Worker  
  `590807098068.dkr.ecr.ap-northeast-2.amazonaws.com/worker:<git-sha>`

## ⚠️ 참고 사항
- 로컬 Docker 환경에서는 AWS Task Role이 없어 SQS 호출 시 credential 에러가 발생함
- 이는 ECS 배포 시 자동 해결되는 정상 시나리오로,  
  Step4(ECS 스모크 테스트)에서 실제 SQS 소비 로그를 검증할 예정