### PR TITLE
fix(worker): ECS 환경에서 DefaultCredentialsProvider 사용

### DIFF
--- a/worker/src/main/java/com/teamA/async/worker/config/AwsClientConfig.java
+++ b/worker/src/main/java/com/teamA/async/worker/config/AwsClientConfig.java
@@ -3,9 +3,7 @@ package com.teamA.async.worker.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
@@ -14,26 +12,14 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 @Configuration
 public class AwsClientConfig {
 
-    @Value("${aws.region:ap-northeast-2}")
+    @Value("${aws.region}")
     private String region;
-
-    // ✅ profile은 ECS에서 없을 수 있으므로 optional로
-    @Value("${aws.profile:}")
-    private String profile;
-
-    private AwsCredentialsProvider credentialsProvider() {
-        if (profile != null && !profile.isBlank()) {
-            return ProfileCredentialsProvider.create(profile);
-        }
-        // ✅ ECS(Task Role), EC2(instance profile), 환경변수 등 자동 탐색
-        return DefaultCredentialsProvider.create();
-    }
 
     @Bean
     public SqsClient sqsClient() {
         return SqsClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(credentialsProvider())
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 
@@ -41,7 +27,7 @@ public class AwsClientConfig {
     public DynamoDbClient dynamoDbClient() {
         return DynamoDbClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(credentialsProvider())
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 
@@ -49,7 +35,7 @@ public class AwsClientConfig {
     public EventBridgeClient eventBridgeClient() {
         return EventBridgeClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(credentialsProvider())
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }


### PR DESCRIPTION
related to #51

## 📌 작업 내용
fix(worker): ECS 환경에서 DefaultCredentialsProvider 사용

## 🔍 작업 상세
- [ ] worker의 AwsClientConfig에서 aws.profile / ProfileCredentialsProvider 싹 빼고 DefaultCredentialsProvider로 바꿈

## 🧪 테스트 결과


## 🗨 기타 참고 사항
- 이슈 번호: #51 
- 논의가 필요한 부분이 있다면 여기에 작성해주세요.
