### PR TITLE
feat/g2-step7-2

### DIFF
--- a/ingest-api/src/main/java/com/teamA/async/ingest/auth/SecurityBypassConfig.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/auth/SecurityBypassConfig.java
@@ -1,0 +1,23 @@
+package com.teamA.async.ingest.auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("g2test")
+public class SecurityBypassConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}

--- a/ingest-api/src/main/java/com/teamA/async/ingest/auth/SecurityConfig.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/auth/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.teamA.async.ingest.auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -11,6 +12,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
+@Profile("!g2test")
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;

--- a/ingest-api/src/main/resources/application-g2test.yml
+++ b/ingest-api/src/main/resources/application-g2test.yml
@@ -1,0 +1,4 @@
+spring:
+profiles:
+  active:g2test
+

--- a/k6/g1_steady_state.js
+++ b/k6/g1_steady_state.js
@@ -7,7 +7,7 @@ import { check, sleep } from "k6";
  * =========================
  */
 const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
-const EVENT_ID = __ENV.EVENT_ID || "EVT-009";
+const EVENT_ID = __ENV.EVENT_ID || "EVT-008";
 const VUS = Number(__ENV.VUS || 2000);
 const DURATION = __ENV.DURATION || "5m"; // steady-state 유지시간
 

--- a/k6/g2_p95_baseline.js
+++ b/k6/g2_p95_baseline.js
@@ -1,0 +1,91 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+/**
+ * =========================
+ * 환경 변수
+ * =========================
+ */
+const BASE_URL = __ENV.BASE_URL;
+const EVENT_ID = __ENV.EVENT_ID;
+
+// ⚠️ 일부러 작게
+const VUS = Number(__ENV.VUS || 50);
+const DURATION = __ENV.DURATION || "60s";
+
+/**
+ * =========================
+ * 시나리오
+ * =========================
+ * - 낮은 동시성
+ * - 일정 속도로 유입
+ * - Queue가 폭증하지 않게 유지
+ */
+export const options = {
+    scenarios: {
+        baseline: {
+            executor: "constant-vus",
+            vus: VUS,
+            duration: DURATION,
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.01"], // 안정성만 체크
+    },
+};
+
+/**
+ * =========================
+ * 유틸
+ * =========================
+ */
+function randomUserId(vu) {
+    return `user-g2-${vu}-${Math.random().toString(36).substring(2, 8)}`;
+}
+
+let token;
+
+export default function () {
+    /**
+     * 1️⃣ VU별 최초 1회 로그인
+     */
+    if (!token) {
+        const userId = randomUserId(__VU);
+
+        const loginRes = http.post(
+            `${BASE_URL}/auth/login`,
+            JSON.stringify({ userId }),
+            { headers: { "Content-Type": "application/json" } }
+        );
+
+        check(loginRes, {
+            "login 200": (r) => r.status === 200,
+        });
+
+        token = loginRes.json("accessToken");
+    }
+
+    /**
+     * 2️⃣ 참여 요청 (enqueue)
+     */
+    const res = http.post(
+        `${BASE_URL}/events/${EVENT_ID}/participations`,
+        null,
+        {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
+
+    check(res, {
+        "202 accepted": (r) => r.status === 202,
+        "has requestId": (r) => r.json("requestId") !== undefined,
+    });
+
+    /**
+     * 너무 빨라지지 않게
+     * → Worker가 즉시 따라잡는 수준 유지
+     */
+    sleep(0.2);
+}

--- a/k6/g2_p95_spike_as_on.js
+++ b/k6/g2_p95_spike_as_on.js
@@ -1,0 +1,54 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL;
+const EVENT_ID = __ENV.EVENT_ID;
+const TOKEN = __ENV.ACCESS_TOKEN;
+
+export const options = {
+    scenarios: {
+        spike: {
+            executor: "ramping-arrival-rate",
+            startRate: 200,
+            timeUnit: "1s",
+            preAllocatedVUs: 500,
+            maxVUs: 2000,
+            stages: [
+                { target: 500, duration: "30s" },
+                { target: 2000, duration: "60s" },
+                { target: 2000, duration: "30s" },
+            ],
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+    },
+};
+
+export default function () {
+    // 🔑 요청마다 고유 userId
+    const userId = `user-${__VU}-${__ITER}-${Date.now()}`;
+
+    const url = `${BASE_URL}/events/${EVENT_ID}/participations`;
+
+    const payload = JSON.stringify({
+        userId,
+    });
+
+    const params = {
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+        },
+        timeout: "5s",
+    };
+
+    const res = http.post(url, payload, params);
+
+    // ✅ G2에서는 이것만 본다
+    check(res, {
+        "202 accepted": (r) => r.status === 202,
+    });
+
+    sleep(0.01);
+}


### PR DESCRIPTION
related to #58 

## 📌 작업 내용
G2 부하 테스트(Step 7-2)를 진행하기 위해  
Ingest API의 인증 로직을 테스트 전용 프로파일에서만 우회하도록 설정하고,  
Auto Scaling 환경에서 p95 E2E 지연(SLO)을 측정할 수 있도록 k6 시나리오를 정리하였다.

## 🔍 작업 상세
- [ ] G2 테스트 전용 프로파일(`g2test`)에서 JWT 인증을 우회하는 Security 설정 추가
- [ ] 기존 SecurityConfig에 프로파일 분기(`!g2test`) 적용하여 운영 로직과 테스트 로직 분리
- [ ] `application-g2test.yml` 추가를 통해 테스트 전용 설정 명시
- [ ] Step 7-1 / Step 7-2 목적에 맞게 k6 테스트 스크립트 정리
  - steady state 시나리오 유지
  - p95 baseline 측정 스크립트 분리
  - Auto Scaling ON 상태의 spike 테스트 시나리오 추가
- [ ] 인증 로직은 제외하고, SQS → Worker → DynamoDB 처리 파이프라인은 기존과 동일하게 유지


코드 수정 후 간단한 테스트
./gradlew :ingest-api:bootRun --args='--spring.profiles.active=g2test' 로 인제스트 키기
<img width="2707" height="1102" alt="image" src="https://github.com/user-attachments/assets/dec57862-6a9d-42ad-a958-5ab06d4add7c" />

<img width="1648" height="852" alt="image" src="https://github.com/user-attachments/assets/af7b9f15-9562-41d4-b982-173fefefc641" />

--> 잘 켜졌고 파워쉘로 토큰없이 포스트 날렸는데 결과 잘 나옴