### PR TITLE
feat/g2_step7_3

### DIFF
--- a/ingest-api/build.gradle
+++ b/ingest-api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
@@ -8,6 +8,7 @@ import com.teamA.async.common.domain.enums.UiResult;
 import com.teamA.async.common.domain.model.RequestItem;
 import com.teamA.async.common.messaging.ParticipationMessage;
 import com.teamA.async.common.transition.StateTransitionService;
+import com.teamA.async.common.transition.TransitionResult;
 import com.teamA.async.ingest.api.dto.ParticipationResponse;
 import com.teamA.async.ingest.ddb.IdempotencyRepository;
 import com.teamA.async.ingest.ddb.RequestWriteRepository;
@@ -45,8 +46,10 @@ public class ParticipationService {
         boolean isDuplicate;
 
         // 1) lock 성공 후 requestId 생성하도록 리팩터링
-        String newRequestId = newRequestId();
-        boolean locked = idempotencyRepository.tryLock(idempotencyPk, newRequestId);
+        // ✅ [문제 1] requestId 단일화: newRequestId를 "절대 사용하지 않는 임시 후보"로만 쓰고,
+        //              participate() 내부의 "실제 ID"는 requestId 하나로만 통일
+        String candidateRequestId = newRequestId();
+        boolean locked = idempotencyRepository.tryLock(idempotencyPk, candidateRequestId);
 
         // 2-A) Lock 실패 => 기존 requestId 반환 (새 requestId 생성 금지 정책 충족)
         if (!locked) {
@@ -62,9 +65,13 @@ public class ParticipationService {
             isDuplicate = true;
 
             // ⚠️ 여기서는 RequestItem을 새로 만들지 않음 (이미 RECEIVED/QUEUED/그 이후 상태로 존재하니까)
+            // ✅ [문제 5] 중복 요청은 SQS/상태전이(QUEUED) 재수행 금지
+            // - 중복인데도 아래 try 블록에서 QUEUED 전이/메시지 enqueue를 시도하면
+            //   requestId 상태와 SQS 메시지 불일치/중복이 다시 생길 수 있음
+            return new ParticipationResponse(requestId, true);
         } else {
             // 최초 요청
-            requestId = newRequestId;
+            requestId = candidateRequestId;
             isDuplicate = false;
 
             long now = System.currentTimeMillis();
@@ -79,62 +86,19 @@ public class ParticipationService {
             requestWriteRepository.putReceived(item);
         }
 
-        // 2-B) Lock 성공 => RequestItem (RECEIVED) 생성 (GSI 미세팅)
-        long now = System.currentTimeMillis();
-        RequestItem item = RequestItem.builder()
-                .requestId(newRequestId)
-                .eventId(eventId)
-                .userId(userId)
-                .status(RequestStatus.RECEIVED)
-                .requestedAt(now)
-                .build();
+        // ✅ [문제 2] RequestItem 중복 생성 제거:
+        // 기존 코드의 "2-B) Lock 성공 => RequestItem (RECEIVED) 생성" 블록은
+        // requestId를 다시 만들거나(또는 다른 변수로) RECEIVED를 2번 쓰는 위험이 있어서 제거함.
 
-        // ❗ G0 규칙: RECEIVED 단계에서는 GSI 세팅하지 않음
-        // 지금 RequestItem.generateKeys()는 GSI도 생성해버리니까, "RECEIVED 전용 키 생성"을 분리하는 걸 추천.
-        // 일단 여기서는 base key만 set하도록 repository에서 강제한다.
-        requestWriteRepository.putReceived(item);
+        // ✅ [문제 4] RECEIVED→QUEUED 전이를 SQS enqueue보다 먼저 수행해서
+        // 워커가 메시지를 먼저 받아도 DDB 상태가 RECEIVED로 남아 defer 무한루프에 빠지지 않게 함.
+        // 실패 처리에서 어떤 상태에서 FAILED_FINAL로 내릴지 기억
+        RequestStatus statusForFailureTransition = RequestStatus.RECEIVED;
 
-        // 중복이든 아니든 SQS로 보내기
+        // 최초 요청일 때만 QUEUED 전이(및 SQS enqueue)를 수행
+        long queuedAt = System.currentTimeMillis();
+
         try {
-            // 3) SQS enqueue 전에 queuedAt 확정 (Worker 생성 금지 규칙)
-            long queuedAt = System.currentTimeMillis();
-
-            ParticipationMessage msg = new ParticipationMessage(
-                    newRequestId, eventId, userId, queuedAt, EventType.FIRST_COME
-            );
-
-            String body = objectMapper.writeValueAsString(msg);
-
-            Map<String, MessageAttributeValue> attributes = Map.of(
-                    "requestId", MessageAttributeValue.builder()
-                            .dataType("String")
-                            .stringValue(newRequestId)
-                            .build(),
-                    "eventId", MessageAttributeValue.builder()
-                            .dataType("String")
-                            .stringValue(eventId)
-                            .build(),
-                    "userId", MessageAttributeValue.builder()
-                            .dataType("String")
-                            .stringValue(userId)
-                            .build(),
-                    "eventType", MessageAttributeValue.builder()
-                            .dataType("String")
-                            .stringValue(EventType.FIRST_COME.name())
-                            .build(),
-                    "queuedAt", MessageAttributeValue.builder()
-                            .dataType("String")
-                            .stringValue(Long.toString(queuedAt))
-                            .build()
-            );
-
-            sqsClient.sendMessage(r -> r
-                    .queueUrl(queueUrl)
-                    .messageBody(body)
-                    .messageAttributes(attributes)
-            );
-
-            // 최초 요청일 때만 RECEIVED -> QUEUED 전이
             if (!isDuplicate) {
                 Map<String, Object> patch = new HashMap<>();
                 patch.put("queuedAt", queuedAt);
@@ -143,11 +107,57 @@ public class ParticipationService {
                 patch.put("GSI2PK", DdbKeyFactory.eventPk(eventId));
                 patch.put("GSI2SK", DdbKeyFactory.eventRequestSk(queuedAt, requestId));
 
-                stateTransitionService.transition(
+                // ✅ [문제 5] 전이 결과 검증: TransitionResult 기반으로 성공 여부 확인
+                // - TransitionResult는 boolean이 아니고, Success/ConditionFailed/UnexpectedError 등으로 내려옴
+                TransitionResult transitionResult = stateTransitionService.transition(
                         requestId,
                         RequestStatus.RECEIVED,
                         RequestStatus.QUEUED,
                         patch
+                );
+
+                // SUCCESS가 아니면 SQS enqueue 금지
+                if (!(transitionResult instanceof TransitionResult.Success)) {
+                    // 전이 실패면 지금 케이스는 "SQS를 보내면 안 되는" 케이스
+                    throw new IllegalStateException("RECEIVED -> QUEUED transition failed: " + transitionResult);
+                }
+
+                statusForFailureTransition = RequestStatus.QUEUED;
+
+                // ✅ [문제 3] 중복 요청은 SQS enqueue 금지 (최초 요청일 때만 보냄)
+                ParticipationMessage msg = new ParticipationMessage(
+                        requestId, eventId, userId, queuedAt, EventType.FIRST_COME
+                );
+
+                String body = objectMapper.writeValueAsString(msg);
+
+                Map<String, MessageAttributeValue> attributes = Map.of(
+                        "requestId", MessageAttributeValue.builder()
+                                .dataType("String")
+                                .stringValue(requestId)
+                                .build(),
+                        "eventId", MessageAttributeValue.builder()
+                                .dataType("String")
+                                .stringValue(eventId)
+                                .build(),
+                        "userId", MessageAttributeValue.builder()
+                                .dataType("String")
+                                .stringValue(userId)
+                                .build(),
+                        "eventType", MessageAttributeValue.builder()
+                                .dataType("String")
+                                .stringValue(EventType.FIRST_COME.name())
+                                .build(),
+                        "queuedAt", MessageAttributeValue.builder()
+                                .dataType("String")
+                                .stringValue(Long.toString(queuedAt))
+                                .build()
+                );
+
+                sqsClient.sendMessage(r -> r
+                        .queueUrl(queueUrl)
+                        .messageBody(body)
+                        .messageAttributes(attributes)
                 );
             }
 
@@ -166,6 +176,8 @@ public class ParticipationService {
             }
 
             // 최초 요청이고 SQS 전송 실패 → FAILED_FINAL로 마무리
+            // ✅ [문제 4] 전이를 QUEUED까지 해둔 뒤 실패했을 수 있으므로,
+            //            현재 위치(statusForFailureTransition)에서 FAILED_FINAL로 내림
             Map<String, Object> patch = new HashMap<>();
             patch.put("resultCode", ResultCode.FAILED_INGEST_ENQUEUE);
             patch.put("uiResult", UiResult.FAILED);
@@ -174,7 +186,7 @@ public class ParticipationService {
 
             stateTransitionService.transition(
                     requestId,
-                    RequestStatus.RECEIVED,
+                    statusForFailureTransition,
                     RequestStatus.FAILED_FINAL,
                     patch
             );

--- a/k6/g2_p95_slo_final.js
+++ b/k6/g2_p95_slo_final.js
@@ -2,52 +2,52 @@ import http from "k6/http";
 import { check, sleep } from "k6";
 
 /**
+ * ===============================
  * ENV
- * BASE_URL=http://alb-async-ingest-xxxx.ap-northeast-2.elb.amazonaws.com
- * EVENT_ID=EVT-P95-1
+ * ===============================
+ * BASE_URL
+ * EVENT_ID
+ * ACCESS_TOKEN
  */
+
 const BASE_URL = __ENV.BASE_URL;
 const EVENT_ID = __ENV.EVENT_ID;
+const TOKEN = __ENV.ACCESS_TOKEN;
 
 export const options = {
     discardResponseBodies: true,
 
     scenarios: {
-        slo: {
+        slo_measurement: {
             executor: "constant-arrival-rate",
-            rate: 30,            // 초당 30 req (SLO용 안정 트래픽)
+            rate: 30,            // 🔑 초당 30 req (SLO 분모)
             timeUnit: "1s",
-            duration: "5m",
+            duration: "5m",      // 🔑 충분한 샘플 수
             preAllocatedVUs: 200,
             maxVUs: 800,
         },
     },
 
     thresholds: {
-        http_req_failed: ["rate<0.01"],      // 실패율 < 1%
-        http_req_duration: ["p(95)<3000"],   // p95 < 3s (SLO 핵심)
+        http_req_failed: ["rate<0.01"],
+
+        // 🔑 SLO 핵심
+        http_req_duration: ["p(95)<3000"], // p95 < 3s
     },
 };
 
 export default function () {
-    /**
-     * 중요:
-     * - requestId는 서버에서 생성해도 되지만
-     * - 명시적으로 보내도 문제 없음
-     * - userId는 이제 멱등성과 무관
-     */
-    const payload = JSON.stringify({
-        userId: `user-${__VU}-${__ITER}`, // 있어도 되고 없어도 됨
-    });
+    const userId = `user-${__VU}-${__ITER}`;
 
     const res = http.post(
         `${BASE_URL}/events/${EVENT_ID}/participations`,
-        payload,
+        null,
         {
             headers: {
+                "Authorization": `Bearer ${TOKEN}`,
                 "Content-Type": "application/json",
             },
-            timeout: "15s",
+            timeout: "5s",
         }
     );
 

--- a/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
+++ b/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
@@ -49,6 +49,16 @@ public class SqsMessageConsumer {
     // ★ [수정] RECEIVED 상태에서 바로 ACK하지 않고, 잠깐 뒤 재시도하기 위한 visibility delay
     private static final int VISIBILITY_DELAY_SECONDS = 2;
 
+    // ✅ [수정] RECEIVED 무한 defer 방지용 상한 (attempt 기준)
+    private static final int MAX_RECEIVED_RETRY = 3;
+
+    // ✅ [수정] RETRYABLE 무한 재등장 방지용 상한 (attempt 기준)
+    private static final int MAX_RETRYABLE_RETRY = 5;
+
+    // ✅ [수정] RETRYABLE backoff (최대 60초)
+    private static final int RETRYABLE_BACKOFF_BASE_SECONDS = 2;
+    private static final int RETRYABLE_BACKOFF_MAX_SECONDS = 60;
+
     // (옵션) messageAttributes에서 복구할 때 사용할 키(ingest가 messageAttributes로도 넣는다면)
     private static final String MA_REQUEST_ID = "requestId";
     private static final String MA_EVENT_ID   = "eventId";
@@ -119,8 +129,36 @@ public class SqsMessageConsumer {
                 Optional<String> cur = requestStateRepository.getCurrentStatus(payload.requestId());
                 String status = cur.orElse("UNKNOWN");
                 if ("RECEIVED".equals(status)) {
-                    log.info("[DEFER/INVALID] requestId={} status={} attempt={} (wait ingest -> retry)", payload.requestId(), status, attempt);
-                    deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                    // ✅ [수정] RECEIVED 무한 defer 방지
+                    if (attempt <= MAX_RECEIVED_RETRY) {
+                        log.info("[DEFER/INVALID] requestId={} status={} attempt={} (wait ingest -> retry)", payload.requestId(), status, attempt);
+                        deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                        return;
+                    }
+
+                    long finishedAt = System.currentTimeMillis();
+                    boolean updated = requestStateRepository.markFailedFinal(
+                            payload.requestId(),
+                            finishedAt,
+                            ResultCode.FAILED_INGEST_ENQUEUE,
+                            FailureClass.NON_RETRYABLE,
+                            "STALE_RECEIVED",
+                            "Request stuck in RECEIVED state (invalid-body path)"
+                    );
+
+                    publisher.publish(buildEvent(
+                            payload, attempt, IS_DLQ,
+                            startedAt, finishedAt,
+                            RequestStatus.FAILED_FINAL,
+                            ResultCode.FAILED_INGEST_ENQUEUE,
+                            new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "STALE_RECEIVED", "Exceeded RECEIVED retry limit"),
+                            false
+                    ));
+
+                    log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (STALE_RECEIVED/INVALID)",
+                            payload.requestId(), updated, attempt);
+
+                    deleteMessage(message);
                     return;
                 }
                 log.info("[SKIP/INVALID] requestId={} already status={}, attempt={}",
@@ -175,12 +213,40 @@ public class SqsMessageConsumer {
             String status = cur.get();
             switch (status) {
                 case "RECEIVED":
-                    log.info("[DEFER] requestId={} status={} attempt={} (wait ingest -> retry)", payload.requestId(), status, attempt);
-                    deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                    // ✅ [수정] RECEIVED 무한 defer 방지
+                    if (attempt <= MAX_RECEIVED_RETRY) {
+                        log.info("[DEFER] requestId={} status={} attempt={} (wait ingest -> retry)", payload.requestId(), status, attempt);
+                        deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                        return;
+                    }
+
+                    long finishedAt = System.currentTimeMillis();
+                    boolean updated = requestStateRepository.markFailedFinal(
+                            payload.requestId(),
+                            finishedAt,
+                            ResultCode.FAILED_INGEST_ENQUEUE,
+                            FailureClass.NON_RETRYABLE,
+                            "STALE_RECEIVED",
+                            "Request stuck in RECEIVED state"
+                    );
+
+                    publisher.publish(buildEvent(
+                            payload, attempt, IS_DLQ,
+                            startedAt, finishedAt,
+                            RequestStatus.FAILED_FINAL,
+                            ResultCode.FAILED_INGEST_ENQUEUE,
+                            new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "STALE_RECEIVED", "Exceeded RECEIVED retry limit"),
+                            false
+                    ));
+
+                    log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (STALE_RECEIVED)",
+                            payload.requestId(), updated, attempt);
+
+                    deleteMessage(message);
                     return;
                 case "QUEUED":
                     log.info("[SKIP] requestId={} status={} attempt={} (race/contend -> ack)", payload.requestId(), status, attempt);
-                    long finishedAt = System.currentTimeMillis();
+                    finishedAt = System.currentTimeMillis();
                     publisher.publish(buildEvent(
                             payload, attempt, IS_DLQ,
                             startedAt, finishedAt,
@@ -271,7 +337,37 @@ public class SqsMessageConsumer {
                 return;
             }
 
-            log.error("[RETRYABLE] worker exception requestId={} attempt={}", payload.requestId(), attempt, e);
+            // ✅ [수정] RETRYABLE 무한 재등장 방지
+            if (attempt <= MAX_RETRYABLE_RETRY) {
+                int backoff = computeRetryableBackoffSeconds(attempt);
+                log.error("[RETRYABLE/DEFER] requestId={} attempt={} backoff={}s", payload.requestId(), attempt, backoff, e);
+                deferMessage(message, backoff);
+                return;
+            }
+
+            long finishedAt = System.currentTimeMillis();
+            boolean updated = requestStateRepository.markFailedFinal(
+                    payload.requestId(),
+                    finishedAt,
+                    ResultCode.FAILED_INGEST_ENQUEUE,
+                    FailureClass.RETRYABLE,
+                    "RETRYABLE_EXHAUSTED",
+                    "Exceeded retryable retry limit: " + e.getClass().getSimpleName()
+            );
+
+            publisher.publish(buildEvent(
+                    payload, attempt, IS_DLQ,
+                    startedAt, finishedAt,
+                    RequestStatus.FAILED_FINAL,
+                    ResultCode.FAILED_INGEST_ENQUEUE,
+                    new ParticipationProcessedFailure(FailureClass.RETRYABLE, "RETRYABLE_EXHAUSTED", e.getMessage()),
+                    false
+            ));
+
+            log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (RETRYABLE_EXHAUSTED)",
+                    payload.requestId(), updated, attempt);
+
+            deleteMessage(message);
         }
     }
 
@@ -396,5 +492,13 @@ public class SqsMessageConsumer {
         } catch (Exception e) {
             log.warn("[ACK FAIL] deleteMessage failed", e);
         }
+    }
+
+    // ✅ [수정] RETRYABLE backoff 계산 (2,4,8,16... 최대 60초)
+    private int computeRetryableBackoffSeconds(int attempt) {
+        int exp = Math.max(0, attempt - 1);
+        long backoff = (long) RETRYABLE_BACKOFF_BASE_SECONDS << exp; // 2 * 2^(attempt-1)
+        if (backoff > RETRYABLE_BACKOFF_MAX_SECONDS) backoff = RETRYABLE_BACKOFF_MAX_SECONDS;
+        return (int) backoff;
     }
 }


### PR DESCRIPTION
related to #58 

## 📌 작업 내용
- G2 부하 테스트(Step 7-2) 과정에서 발견된 **Ingest–Worker 파이프라인 불일치 문제를 수정**하고,
  SQS 메시지 적체 및 무한 재시도 현상을 근본적으로 해결함.
- Request 상태 전이 일관성 보장 및 중복 요청 처리 로직을 정리하여,
  **RECEIVED → QUEUED → PROCESSING → FINAL** 흐름이 안정적으로 유지되도록 개선함.

## 🔍 작업 상세
- [ ] **Ingest – requestId 단일화**
  - participate() 내에서 requestId를 하나로 통일
  - DDB(RequestItem), SQS 메시지, 상태 전이에 동일 requestId 사용
- [ ] **Ingest – RequestItem 중복 생성 제거**
  - lock 성공 시에만 RECEIVED 상태 RequestItem 1회 생성
  - 중복 요청 시 RECEIVED/QUEUED 재생성 방지
- [ ] **Ingest – 중복 요청 SQS enqueue 차단**
  - idempotency lock 실패(중복 요청) 시 SQS 전송 및 상태 전이 미수행
- [ ] **Ingest – 상태 전이 선행 및 검증**
  - RECEIVED → QUEUED 전이를 SQS enqueue 이전에 수행
  - 전이 실패 시 SQS 전송 금지 및 FAILED_FINAL로 종료
- [ ] **Worker – RECEIVED 무한 defer 방지**
  - RECEIVED 상태 재시도 횟수 상한 도입
  - RETRYABLE 예외에 대해 backoff 및 최대 재시도 횟수 제한
- [ ] **Worker – 메시지 삭제 보장**
  - 최종 상태(SUCCEEDED / REJECTED / FAILED_FINAL) 도달 시 반드시 deleteMessage 호출
  - SQS numberOfMessagesDeleted가 정상적으로 증가하도록 보장
