### PR TITLE
user api modify-2

### DIFF
--- a/common/src/main/java/com/teamA/async/common/domain/model/RequestItem.java
+++ b/common/src/main/java/com/teamA/async/common/domain/model/RequestItem.java
@@ -69,22 +69,44 @@ public class RequestItem {
 
     // Domain Attributes
     // 식별자 정보
+    @Getter(onMethod_ = {@DynamoDbAttribute("requestId")})
     private String requestId;
+
+    @Getter(onMethod_ = {@DynamoDbAttribute("eventId")})
     private String eventId;
+
+    @Getter(onMethod_ = {@DynamoDbAttribute("userId")})
     private String userId;
+
+    @Getter(onMethod_ = {@DynamoDbAttribute("eventType")})
+    private EventType eventType;
+
+    @Getter(onMethod_ = {@DynamoDbAttribute("status")})
+    private RequestStatus status;
 
     // 상태 및 결과 정보
     // Enum들은 기본적으로 name() (문자열)으로 저장됨
-    private EventType eventType;
-    private RequestStatus status;
+    @Getter(onMethod_ = {@DynamoDbAttribute("uiResult")})
     private UiResult uiResult;
+
+    @Getter(onMethod_ = {@DynamoDbAttribute("resultCode")})
     private ResultCode resultCode;
 
     // 타임스탬프
-    private Long requestedAt; // 202 응답 시점
-    private Long queuedAt;    // SQS Enqueue 시점
-    private Long startedAt;   // Worker 처리 시작
-    private Long finishedAt;  // 처리 완료
+    @Getter(onMethod_ = {@DynamoDbAttribute("requestedAt")})
+    private Long requestedAt;
+
+    // SQS Enqueue 시점
+    @Getter(onMethod_ = {@DynamoDbAttribute("queuedAt")})
+    private Long queuedAt;
+
+    // Worker 처리 시작
+    @Getter(onMethod_ = {@DynamoDbAttribute("startedAt")})
+    private Long startedAt;
+
+    // 처리 완료
+    @Getter(onMethod_ = {@DynamoDbAttribute("finishedAt")})
+    private Long finishedAt;
 
     // 실패 상세 정보
     private FailureClass failureClass;

--- a/ingest-api/src/main/java/com/teamA/async/ingest/api/ParticipationController.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/api/ParticipationController.java
@@ -1,5 +1,6 @@
 package com.teamA.async.ingest.api;
 
+import com.teamA.async.common.domain.enums.EventType;
 import com.teamA.async.ingest.api.dto.ParticipationResponse;
 import com.teamA.async.ingest.auth.UserResolver;
 import com.teamA.async.ingest.service.ParticipationService;
@@ -17,12 +18,12 @@ public class ParticipationController {
     private final UserResolver userResolver;
 
     @PostMapping("/events/{eventId}/apply")
-    public ResponseEntity<ParticipationResponse> participate(@PathVariable String eventId) {
+    public ResponseEntity<ParticipationResponse> participate(@PathVariable String eventId, @RequestParam EventType eventType) {
         String userId = userResolver.currentUserId(); // JWT에서만 추출
 
         log.info("[INGEST HIT] eventId={}, userId={}", eventId, userId);
 
-        ParticipationResponse res = participationService.participate(eventId, userId);
+        ParticipationResponse res = participationService.participate(eventId, userId, eventType);
         return ResponseEntity.accepted().body(res); // 항상 202
 
     }

--- a/ingest-api/src/main/java/com/teamA/async/ingest/auth/SecurityConfig.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/auth/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                         .requestMatchers("/__smoke/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/events/**").permitAll()
+                        .requestMatchers("/me/**", "/requests/**").permitAll()
                         // OPTIONS 요청은 인증 없이 통과시켜야 CORS가 정상 작동합니다.
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()

--- a/ingest-api/src/main/java/com/teamA/async/ingest/ddb/RequestWriteRepository.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/ddb/RequestWriteRepository.java
@@ -41,6 +41,10 @@ public class RequestWriteRepository {
         map.put("status", AttributeValue.builder().s(item.getStatus().name()).build());
         map.put("requestedAt", AttributeValue.builder().n(Long.toString(item.getRequestedAt())).build());
 
+        if (item.getEventType() != null) {
+            map.put("eventType", AttributeValue.builder().s(item.getEventType().name()).build());
+        }
+
         // ❌ GSI1PK/GSI1SK/GSI2PK/GSI2SK는 절대 넣지 않음 (RECEIVED 단계 규칙)
 
         dynamoDbClient.putItem(PutItemRequest.builder()

--- a/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
+++ b/ingest-api/src/main/java/com/teamA/async/ingest/service/ParticipationService.java
@@ -40,7 +40,7 @@ public class ParticipationService {
     private String queueUrl;
 
     // 시간은 우선 System.currentTimeMillis()로 가고, 나중에 common Clock으로 교체해도 됨
-    public ParticipationResponse participate(String eventId, String userId) {
+    public ParticipationResponse participate(String eventId, String userId, EventType eventType) {
         String idempotencyPk = DdbKeyFactory.idempotencyPk(eventId, userId);
         String requestId;
         boolean isDuplicate;
@@ -81,6 +81,7 @@ public class ParticipationService {
                     .userId(userId)
                     .status(RequestStatus.RECEIVED)
                     .requestedAt(now)
+                    .eventType(eventType)
                     .build();
 
             requestWriteRepository.putReceived(item);
@@ -126,7 +127,7 @@ public class ParticipationService {
 
                 // ✅ [문제 3] 중복 요청은 SQS enqueue 금지 (최초 요청일 때만 보냄)
                 ParticipationMessage msg = new ParticipationMessage(
-                        requestId, eventId, userId, queuedAt, EventType.FIRST_COME
+                        requestId, eventId, userId, queuedAt, eventType
                 );
 
                 String body = objectMapper.writeValueAsString(msg);
@@ -146,7 +147,7 @@ public class ParticipationService {
                                 .build(),
                         "eventType", MessageAttributeValue.builder()
                                 .dataType("String")
-                                .stringValue(EventType.FIRST_COME.name())
+                                .stringValue(eventType.name())
                                 .build(),
                         "queuedAt", MessageAttributeValue.builder()
                                 .dataType("String")

--- a/worker/src/main/java/com/teamA/async/worker/ddb/EventCapacityRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/EventCapacityRepository.java
@@ -32,7 +32,7 @@ public class EventCapacityRepository {
                         .s(DdbKeyFactory.eventPk(eventId))
                         .build(),
                 "SK", AttributeValue.builder()
-                        .s("CAPACITY") // ❗ 키팩토리에 메서드는 없고 상수만 존재
+                        .s("CONFIG") // ❗ 키팩토리에 메서드는 없고 상수만 존재
                         .build()
         );
 


### PR DESCRIPTION
1. eventType 동적 구별, null 문제 해결
2. status: REJECTED 문제 해결

## 📌 작업 내용
1. eventType 동적 구별로 변경. 원래 FIRST_COME으로 고정되어 있었음.
2. eventType null 문제 해결
3. status: REJECTED 문제 해결

## 🔍 작업 상세
- [x] common > RequestItems, EventItems DDB와 필드명 일치시키도록 코드 변경
- [x] injest-api > 
  - [x] ParticipationService: eventType 매개변수 추가
  - [x] RequestWriteRepository: eventType 필드 추가
  - [x] ParticipationController: eventType 필드 추가
  - [x] RequestQueryController: Builder 쪽 .eventType(item.getEventType()) 추가
- [x] worker > EventCapacityRepository: SK를 CONFIG로 변경 

## 🧪 테스트 결과
- [x] 로컬 테스트 완료 -> 노션 api 명세서 페이지 사진 참고

## 🗨 기타 참고 사항
- 이슈 번호: #62
