### PR TITLE
feat/after-g2-lottery1

### DIFF
--- a/admin-api/src/main/java/com/teamA/async/admin/api/LotteryAdminController.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/api/LotteryAdminController.java
@@ -1,0 +1,62 @@
+package com.teamA.async.admin.api;
+
+import com.teamA.async.admin.domain.EventItem;
+import com.teamA.async.admin.domain.EventStatus;
+import com.teamA.async.admin.domain.EventType;
+import com.teamA.async.admin.service.AdminEventService;
+import com.teamA.async.admin.service.LotteryDrawService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/events")
+@RequiredArgsConstructor
+public class LotteryAdminController {
+
+    private final AdminEventService adminEventService;
+    private final LotteryDrawService lotteryDrawService;
+
+    @PostMapping("/{eventId}/lottery/draw")
+    public ResponseEntity<Void> draw(@PathVariable String eventId) {
+
+        EventItem event = adminEventService.getOrThrow(eventId);
+
+        // 1️⃣ LOTTERY 이벤트만 허용
+        if (event.getType() != EventType.LOTTERY) {
+            throw new RuntimeException("NOT_LOTTERY_EVENT");
+        }
+
+        // 2️⃣ CLOSED 상태에서만 허용
+        if (event.getStatus() != EventStatus.CLOSED) {
+            throw new RuntimeException("EVENT_NOT_CLOSED");
+        }
+
+        // 3️⃣ 재실행 방지
+        if (event.getLotteryDrawnAt() != null) {
+            throw new RuntimeException("LOTTERY_ALREADY_DRAWN");
+        }
+
+        /*
+         * G2 이후 합의:
+         * - LOTTERY 이벤트는 winners 필드를 추가하지 않는다.
+         * - draw 시점에서만 capacityTotal을 "당첨자 수"로 해석한다.
+         */
+        if (event.getCapacityTotal() == null || event.getCapacityTotal() <= 0) {
+            throw new IllegalStateException(
+                    "LOTTERY requires capacityTotal as winners at draw time"
+            );
+        }
+
+        // 4️⃣ 추첨 시점 기록 (1회 보장)
+        adminEventService.markLotteryDrawn(eventId);
+
+        // 5️⃣ 추첨 실행
+        lotteryDrawService.draw(
+                eventId,
+                event.getCapacityTotal().intValue()
+        );
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/admin-api/src/main/java/com/teamA/async/admin/ddb/DynamoDbItemMapper.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/ddb/DynamoDbItemMapper.java
@@ -1,0 +1,20 @@
+package com.teamA.async.admin.ddb;
+
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.model.RequestItem;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.Map;
+
+public class DynamoDbItemMapper {
+
+    public static RequestItem toRequestItem(Map<String, AttributeValue> item) {
+        return RequestItem.builder()
+                .requestId(item.get("requestId").s())
+                .eventId(item.get("eventId").s())
+                .userId(item.get("userId").s())
+                .status(RequestStatus.valueOf(item.get("status").s()))
+                .queuedAt(Long.parseLong(item.get("queuedAt").n()))
+                .build();
+    }
+}

--- a/admin-api/src/main/java/com/teamA/async/admin/ddb/EventRepository.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/ddb/EventRepository.java
@@ -134,4 +134,41 @@ public class EventRepository {
                 .updatedAt(Long.parseLong(item.get("updatedAt").n()))
                 .build();
     }
+    //Lottery
+    public void markLotteryDrawn(String eventId, long drawnAt) {
+
+        Map<String, AttributeValue> key = Map.of(
+                "PK", AttributeValue.builder()
+                        .s(AdminDdbKeyFactory.eventPk(eventId))
+                        .build(),
+                "SK", AttributeValue.builder()
+                        .s(AdminDdbKeyFactory.metaSk())
+                        .build()
+        );
+
+        Map<String, String> names = Map.of(
+                "#lotteryDrawnAt", "lotteryDrawnAt",
+                "#updatedAt", "updatedAt"
+        );
+
+        Map<String, AttributeValue> values = Map.of(
+                ":drawnAt", AttributeValue.builder()
+                        .n(Long.toString(drawnAt))
+                        .build(),
+                ":now", AttributeValue.builder()
+                        .n(Long.toString(drawnAt))
+                        .build()
+        );
+
+        dynamoDbClient.updateItem(UpdateItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                .updateExpression("SET #lotteryDrawnAt = :drawnAt, #updatedAt = :now")
+                .expressionAttributeNames(names)
+                .expressionAttributeValues(values)
+                .build());
+    }
+
+
+
 }

--- a/admin-api/src/main/java/com/teamA/async/admin/ddb/RequestItemRepository.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/ddb/RequestItemRepository.java
@@ -1,0 +1,56 @@
+package com.teamA.async.admin.ddb;
+
+import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import com.teamA.async.common.domain.model.RequestItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class RequestItemRepository {
+
+    private final DynamoDbClient dynamoDbClient;
+
+    @Value("${ddb.table-name}")
+    private String tableName;
+
+    public List<RequestItem> findPendingByEvent(String eventId) {
+
+        QueryRequest request = QueryRequest.builder()
+                .tableName(tableName)
+                .indexName("GSI2")
+                .keyConditionExpression("GSI2PK = :pk")
+                .filterExpression("#st IN (:queued, :processing)")
+                .expressionAttributeNames(Map.of(
+                        "#st", "status"
+                ))
+                .expressionAttributeValues(Map.of(
+                        ":pk", AttributeValue.builder()
+                                .s(DdbKeyFactory.eventPk(eventId))
+                                .build(),
+                        ":queued", AttributeValue.builder()
+                                .s("QUEUED")
+                                .build(),
+                        ":processing", AttributeValue.builder()
+                                .s("PROCESSING")
+                                .build()
+                ))
+                .build();
+
+        QueryResponse response = dynamoDbClient.query(request);
+
+        List<RequestItem> result = new ArrayList<>();
+        for (Map<String, AttributeValue> item : response.items()) {
+            result.add(DynamoDbItemMapper.toRequestItem(item));
+        }
+        return result;
+    }
+
+}

--- a/admin-api/src/main/java/com/teamA/async/admin/domain/EventItem.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/domain/EventItem.java
@@ -12,9 +12,15 @@ public class EventItem {
     private final EventStatus status;
 
     private final Long capacityTotal;   // FIRST_COME only (nullable)
+    private final Integer winners;       // LOTTERY only
+
+
     private final Long openAt;          // epoch millis (nullable)
     private final Long closeAt;         // epoch millis (nullable)
 
     private final Long createdAt;       // epoch millis
     private final Long updatedAt;       // epoch millis
+
+    private Long lotteryDrawnAt;        // LOTTERY only
+
 }

--- a/admin-api/src/main/java/com/teamA/async/admin/service/AdminEventService.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/service/AdminEventService.java
@@ -113,4 +113,10 @@ public class AdminEventService {
     public static class ConflictException extends RuntimeException {
         public ConflictException(String message) { super(message); }
     }
+
+    public void markLotteryDrawn(String eventId) {
+        eventRepository.markLotteryDrawn(eventId, System.currentTimeMillis());
+    }
+
+
 }

--- a/admin-api/src/main/java/com/teamA/async/admin/service/LotteryDrawService.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/service/LotteryDrawService.java
@@ -1,0 +1,42 @@
+package com.teamA.async.admin.service;
+
+import com.teamA.async.admin.ddb.RequestItemRepository;
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.enums.ResultCode;
+import com.teamA.async.common.domain.enums.UiResult;
+import com.teamA.async.common.domain.model.RequestItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LotteryDrawService {
+
+    private final RequestItemRepository requestItemRepository;
+    private final RequestItemResultWriter resultWriter;
+
+    public void draw(String eventId, int winners) {
+
+        // 1️⃣ 응모 대상 조회
+        List<RequestItem> all = requestItemRepository.findPendingByEvent(eventId);
+
+        List<RequestItem> candidates = all.stream()
+                .filter(r -> r.getStatus() == RequestStatus.QUEUED
+                        || r.getStatus() == RequestStatus.PROCESSING)
+                .toList();
+
+        // 2️⃣ 랜덤 셔플
+        Collections.shuffle(candidates);
+
+        // 3️⃣ 당첨 / 탈락 분리
+        List<RequestItem> win = candidates.stream().limit(winners).toList();
+        List<RequestItem> lose = candidates.stream().skip(winners).toList();
+
+        // 4️⃣ 결과 반영
+        resultWriter.markWinners(win);
+        resultWriter.markLosers(lose);
+    }
+}

--- a/admin-api/src/main/java/com/teamA/async/admin/service/RequestItemResultWriter.java
+++ b/admin-api/src/main/java/com/teamA/async/admin/service/RequestItemResultWriter.java
@@ -1,0 +1,90 @@
+package com.teamA.async.admin.service;
+
+import com.teamA.async.common.domain.enums.RequestStatus;
+import com.teamA.async.common.domain.enums.ResultCode;
+import com.teamA.async.common.domain.enums.UiResult;
+import com.teamA.async.common.domain.model.RequestItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class RequestItemResultWriter {
+
+    private final DynamoDbClient dynamoDbClient;
+
+    @Value("${ddb.table-name}")
+    private String tableName;
+
+    /**
+     * LOTTERY 당첨 처리
+     * - status: SUCCEEDED
+     * - uiResult: SUCCESS
+     * - resultCode: SUCCESS
+     */
+    public void markWinners(List<RequestItem> items) {
+        items.forEach(r ->
+                updateResult(
+                        r,
+                        RequestStatus.SUCCEEDED,
+                        UiResult.SUCCESS,
+                        ResultCode.SUCCESS
+                )
+        );
+    }
+
+    /**
+     * LOTTERY 탈락 처리
+     * - status: REJECTED
+     * - uiResult: REJECTED
+     * - resultCode: REJECTED_CAPACITY
+     */
+    public void markLosers(List<RequestItem> items) {
+        items.forEach(r ->
+                updateResult(
+                        r,
+                        RequestStatus.REJECTED,
+                        UiResult.REJECTED,
+                        ResultCode.REJECTED_CAPACITY
+                )
+        );
+    }
+
+    private void updateResult(RequestItem r,
+                              RequestStatus status,
+                              UiResult uiResult,
+                              ResultCode code) {
+
+        long now = System.currentTimeMillis();
+
+        dynamoDbClient.updateItem(UpdateItemRequest.builder()
+                .tableName(tableName)
+                .key(Map.of(
+                        "PK", AttributeValue.builder().s(r.getPk()).build(),
+                        "SK", AttributeValue.builder().s(r.getSk()).build()
+                ))
+                .updateExpression(
+                        "SET #status = :s, #ui = :ui, #code = :c, #finishedAt = :now"
+                )
+                .expressionAttributeNames(Map.of(
+                        "#status", "status",
+                        "#ui", "uiResult",
+                        "#code", "resultCode",
+                        "#finishedAt", "finishedAt"
+                ))
+                .expressionAttributeValues(Map.of(
+                        ":s", AttributeValue.builder().s(status.name()).build(),
+                        ":ui", AttributeValue.builder().s(uiResult.name()).build(),
+                        ":c", AttributeValue.builder().s(code.name()).build(),
+                        ":now", AttributeValue.builder().n(Long.toString(now)).build()
+                ))
+                .build());
+    }
+}

--- a/common/src/main/java/com/teamA/async/common/domain/model/EventItem.java
+++ b/common/src/main/java/com/teamA/async/common/domain/model/EventItem.java
@@ -27,6 +27,9 @@ public class EventItem {
 
     private Integer capacityRemaining; // 현재 남은 좌석 (실시간 변동)
 
+    // LOTTERY 전용 필드
+    private Long lotteryDrawnAt; // null이면 아직 추첨 안 됨
+
     @DynamoDbPartitionKey
     @DynamoDbAttribute("PK")
     public String getPk() {


### PR DESCRIPTION
related to #75

## 📌 작업 내용
- LOTTERY(응모형) 이벤트를 위한 **추첨 실행 API 및 처리 로직**을 추가했습니다.
- 기존 FIRST_COME 비동기 엔진(Ingest / Worker / 상태 머신)은 수정하지 않고,
  LOTTERY 전용 **처리 시점 제어 및 결과 반영 레이어**만 구현했습니다.

## 🔍 작업 상세
- [x] LOTTERY 이벤트 전용 추첨 실행 Admin API 구현  
  - `POST /admin/events/{eventId}/lottery/draw`
- [x] LOTTERY 도메인 규칙 반영
  - 참여 요청 흐름은 FIRST_COME과 동일 (Ingest → SQS → Worker)
  - LOTTERY의 차이는 **처리 시점(추첨 시점)**과 **결과 해석**으로만 한정
  - DB 상태 머신(`RECEIVED → QUEUED → PROCESSING → SUCCEEDED | REJECTED | FAILED_FINAL`) 확장 없음
- [x] 추첨 실행 조건 검증
  - `Event.type == LOTTERY`
  - `Event.status == CLOSED`
  - 이미 추첨된 이벤트(`lotteryDrawnAt != null`) 재호출 시 즉시 거절
- [x] 추첨 재실행 방지 로직 구현
  - EventItem에 `lotteryDrawnAt` 플래그 사용
  - draw API 진입 시 중복 실행 여부 선확인
  - draw 성공 시 플래그 업데이트
- [x] 추첨 대상 조회 로직 구현
  - eventId 기준 RequestItem 조회
  - `status ∈ { QUEUED, PROCESSING }` 인 요청만 추첨 대상
  - 이미 `SUCCEEDED / REJECTED` 된 요청 제외
  - GSI2(Event 기준) Query 사용 (Scan 미사용)
- [x] 추첨 알고리즘 구현
  - 단순 랜덤 방식 (`shuffle → pick N`)
  - N = 이벤트에 설정된 당첨자 수
  - winners / losers 리스트 명확히 분리
- [x] 추첨 결과 반영
  - 당첨자:
    - `status = SUCCEEDED`
    - `uiResult = SUCCESS`
    - `resultCode = LOTTERY_WIN`
  - 탈락자:
    - `status = REJECTED`
    - `uiResult = REJECTED`
    - `resultCode = LOTTERY_LOST`
  - 모든 결과에 `finishedAt` 타임스탬프 기록

> 본 PR은 LOTTERY 처리 로직 및 API 구현까지 포함하며,  
> Postman을 통한 실제 추첨 실행 테스트는 후속으로 진행 예정입니다.

