### PR TITLE
dlq_2/3/4/5/6

### DIFF
--- a/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
+++ b/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
@@ -11,13 +11,18 @@ import com.teamA.async.worker.analytics.publisher.ParticipationEventBridgePublis
 import com.teamA.async.worker.ddb.EventCapacityRepository;
 import com.teamA.async.worker.ddb.RequestStateRepository;
 import com.teamA.async.worker.ddb.WorkerIdempotencyRepository;
+import com.teamA.async.worker.dlq.DlqSender;
+import com.teamA.async.worker.exception.BusinessRuleViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
+import io.micrometer.core.instrument.Counter; //dlq 전략수정
+import io.micrometer.core.instrument.MeterRegistry; //dlq 전략수정
 
 import org.springframework.stereotype.Component;
 import jakarta.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct; //dlq 전략수정
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.*;
@@ -27,6 +32,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+//dlq전략수정 : 네트워크 timeout/일시 장애 Retryable 명시용 import (JDK 표준이라 컴파일 안전)
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 @Component
@@ -42,6 +54,13 @@ public class SqsMessageConsumer {
 
     @Value("${sqs.queue-url}")
     private String queueUrl;
+
+    //dlq 전략수정
+    private final DlqSender dlqSender;
+    private final MeterRegistry meterRegistry;
+    private Counter duplicateSkipCounter;
+    private Counter nonRetryableDlqCounter;
+    private Counter retryableExceptionCounter; //dlq 전략수정
 
     // 나중에 yml + @Value로 바꾸기
     private static final int SCHEMA_VERSION = 1;
@@ -77,6 +96,23 @@ public class SqsMessageConsumer {
     // =========================================================
     private final ExecutorService executor =
             Executors.newFixedThreadPool(4);
+
+    @PostConstruct //dlq 전략 수정
+    public void initMetrics() {
+        this.duplicateSkipCounter = Counter.builder("duplicate_skip_count")
+                .description("Duplicate requests skipped by idempotency lock")
+                .register(meterRegistry);
+
+        // 기본 카운터(전체 합)도 하나 두면 운영이 편함
+        this.nonRetryableDlqCounter = Counter.builder("non_retryable_dlq_count")
+                .description("Non-retryable messages sent to DLQ")
+                .register(meterRegistry);
+
+        this.retryableExceptionCounter = Counter.builder("retryable_exception_count") //dlq 전략수정
+                .description("Retryable exceptions while processing messages") //dlq 전략수정
+                .register(meterRegistry); //dlq 전략수정
+    }
+
 
     @Scheduled(fixedDelay = 3000)
     public void pollMessages() {
@@ -127,6 +163,26 @@ public class SqsMessageConsumer {
             } catch (Exception attrEx) {
                 log.warn("[NON-RETRYABLE] invalid body and cannot recover attrs. attempt={} body={}",
                         attempt, safeBody(message), bodyEx);
+
+                String nonRetryableReasonCode = "INVALID_SCHEMA"; //dlq전략수정 : undefined symbol 해결 + reasonCode 고정
+
+                if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
+                meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode)
+                        .increment();
+
+                log.error("[DLQ SEND] reasonCode={} requestId=? eventId=? userId=? attempt={} messageId={}",
+                        nonRetryableReasonCode, attempt, message.messageId());
+
+                // dlq전략수정 : 즉시 DLQ + ACK
+                dlqSender.send(
+                        safeBody(message),
+                        message.messageId(),
+                        attempt,
+                        "NON_RETRYABLE",
+                        nonRetryableReasonCode,
+                        Map.of()
+                );
+
                 deleteMessage(message);
                 return;
             }
@@ -141,6 +197,7 @@ public class SqsMessageConsumer {
 
         if (!first) {
             log.info("[DUPLICATE] skip requestId={}", payload.requestId());
+            if (duplicateSkipCounter != null) duplicateSkipCounter.increment(); //dlq 전략수정
             deleteMessage(message);
             return;
         }
@@ -208,6 +265,29 @@ public class SqsMessageConsumer {
                     log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (STALE_RECEIVED)",
                             payload.requestId(), updated, attempt);
 
+                    String nonRetryableReasonCode = "STALE_RECEIVED"; //dlq 전략수정 : undefined symbol 해결
+
+                    if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
+                    meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode)
+                            .increment();
+
+                    log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
+                            nonRetryableReasonCode, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
+
+                    // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK (send 실패 시 delete까지 가지 않아서 재시도됨)
+                    dlqSender.send(
+                            message.body(),
+                            message.messageId(),
+                            attempt,
+                            "NON_RETRYABLE",
+                            nonRetryableReasonCode,
+                            Map.of(
+                                    "requestId", payload.requestId(),
+                                    "eventId", payload.eventId(),
+                                    "userId", payload.userId()
+                            )
+                    );
+
                     deleteMessage(message);
                     return;
                 case "QUEUED":
@@ -223,6 +303,52 @@ public class SqsMessageConsumer {
                     ));
                     deleteMessage(message);
                     return;
+                case "PROCESSING":
+                    // 다른 워커가 처리 중이거나, 이전 시도에서 visibility timeout으로 재수신된 케이스
+                    // ✅ 바로 ACK하면 유실/오판 위험. 잠깐 defer로 밀어줌.
+                    if (attempt <= MAX_RETRYABLE_RETRY) {
+                        log.info("[DEFER] requestId={} status=PROCESSING attempt={} (in-flight -> retry later)",
+                                payload.requestId(), attempt);
+                        deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                        return;
+                    }
+
+                    // ✅ 너무 오래 PROCESSING이면 "의미 있는 실패"로 보고 즉시 DLQ + ACK (선택적으로)
+                    long finishedAt2 = System.currentTimeMillis();
+                    requestStateRepository.markFailedFinal(
+                            payload.requestId(),
+                            finishedAt2,
+                            ResultCode.FAILED_WORKER_EXCEPTION,
+                            FailureClass.NON_RETRYABLE,
+                            "STALE_PROCESSING",
+                            "Request stuck in PROCESSING state"
+                    );
+
+                    String nonRetryableReasonCode2 = "STALE_PROCESSING"; //dlq 전략수정 : undefined symbol 해결
+
+                    if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
+                    meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode2)
+                            .increment();
+
+                    log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
+                            nonRetryableReasonCode2, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
+
+                    // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK
+                    dlqSender.send(
+                            message.body(),
+                            message.messageId(),
+                            attempt,
+                            "NON_RETRYABLE",
+                            nonRetryableReasonCode2,
+                            Map.of(
+                                    "requestId", payload.requestId(),
+                                    "eventId", payload.eventId(),
+                                    "userId", payload.userId()
+                            )
+                    );
+                    deleteMessage(message);
+                    return;
+
                 default:
                     log.info("[SKIP] requestId={} status={} attempt={} (dup -> ack)", payload.requestId(), status, attempt);
                     finishedAt = System.currentTimeMillis();
@@ -280,13 +406,21 @@ public class SqsMessageConsumer {
             FailureClass cls = classifyFailure(e);
 
             if (cls == FailureClass.NON_RETRYABLE) {
+
+                //dlq전략수정 : 비즈니스 규칙 위반은 reasonCode를 그대로 DLQ/상태에 박아 운영 분류를 1분 내로 만든다
+                String nonRetryableReasonCode = "WORKER_NON_RETRYABLE";
+                if (e instanceof BusinessRuleViolationException) {
+                    BusinessRuleViolationException brve = (BusinessRuleViolationException) e;
+                    nonRetryableReasonCode = brve.getReasonCode();
+                }
+
                 long finishedAt = System.currentTimeMillis();
                 requestStateRepository.markFailedFinal(
                         payload.requestId(),
                         finishedAt,
-                        ResultCode.FAILED_INGEST_ENQUEUE,
+                        ResultCode.FAILED_WORKER_EXCEPTION, // dlq 전략수정 : Worker에서 난 예외는 WORKER_EXCEPTION이 더 정확
                         FailureClass.NON_RETRYABLE,
-                        "WORKER_NON_RETRYABLE",
+                        nonRetryableReasonCode,
                         e.getMessage()
                 );
 
@@ -294,46 +428,70 @@ public class SqsMessageConsumer {
                         payload, attempt, IS_DLQ,
                         startedAt, finishedAt,
                         RequestStatus.FAILED_FINAL,
-                        ResultCode.FAILED_INGEST_ENQUEUE,
-                        new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "WORKER_NON_RETRYABLE", e.getMessage()),
+                        ResultCode.FAILED_WORKER_EXCEPTION, // dlq 전략수정
+                        new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, nonRetryableReasonCode, e.getMessage()),
                         false
                 ));
+
+                if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
+                meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode)
+                        .increment();
+
+                log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
+                        nonRetryableReasonCode, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
+
+                // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK (send 실패 시 delete까지 가지 않아서 재시도됨)
+                dlqSender.send(
+                        message.body(),
+                        message.messageId(),
+                        attempt,
+                        "NON_RETRYABLE",
+                        nonRetryableReasonCode,
+                        Map.of(
+                                "requestId", payload.requestId(),
+                                "eventId", payload.eventId(),
+                                "userId", payload.userId()
+                        ),
+                        e // dlq전략수정: 예외 전달( digest 채우기 )
+                );
 
                 deleteMessage(message);
                 return;
             }
 
+            if (retryableExceptionCounter != null) retryableExceptionCounter.increment(); //dlq 전략수정
+
+            log.warn("[RETRYABLE] ex={} attempt={} requestId={} eventId={} userId={} messageId={}",
+                    e.getClass().getSimpleName(), attempt, payload.requestId(), payload.eventId(), payload.userId(), message.messageId(), e);
+
+            // dlq전략수정 : Retryable은 "throw/재시도"가 목표.
+            // - 폴링 방식이므로 deleteMessage만 안 하면 SQS가 재전달함
+            // - 하지만 현재 상태가 PROCESSING에 머물면 다음 시도에서 재처리가 막히므로 QUEUED로 롤백이 필요
+            boolean rolledBack = false;
+            try {
+                // dlq전략수정 : PROCESSING -> QUEUED 롤백 (RequestStateRepository에 메서드 추가 필요: releaseProcessingToQueued)
+                rolledBack = requestStateRepository.releaseProcessingToQueued(payload.requestId(), startedAt); //dlq 전략수정
+            } catch (Exception rollbackEx) {
+                // 롤백 실패는 더 큰 문제(상태 오염 가능). 그래도 ACK는 하지 않는다.
+                log.warn("[ROLLBACK FAIL] requestId={} attempt={} (processing->queued)", payload.requestId(), attempt, rollbackEx);
+            }
+
             // [수정] RETRYABLE 무한 재등장 방지
             if (attempt <= MAX_RETRYABLE_RETRY) {
                 int backoff = computeRetryableBackoffSeconds(attempt);
-                log.error("[RETRYABLE/DEFER] requestId={} attempt={} backoff={}s", payload.requestId(), attempt, backoff, e);
+                log.warn("[RETRYABLE/DEFER] requestId={} attempt={} backoff={}s rollbackToQueued={}", //dlq전략수정 (warn로 낮춤)
+                        payload.requestId(), attempt, backoff, rolledBack, e);
                 deferMessage(message, backoff);
-                return;
+                return; // ✅ ACK 금지 (deleteMessage 호출하면 안 됨)
             }
 
-            long finishedAt = System.currentTimeMillis();
-            boolean updated = requestStateRepository.markFailedFinal(
-                    payload.requestId(),
-                    finishedAt,
-                    ResultCode.FAILED_INGEST_ENQUEUE,
-                    FailureClass.RETRYABLE,
-                    "RETRYABLE_EXHAUSTED",
-                    "Exceeded retryable retry limit: " + e.getClass().getSimpleName()
-            );
-
-            publisher.publish(buildEvent(
-                    payload, attempt, IS_DLQ,
-                    startedAt, finishedAt,
-                    RequestStatus.FAILED_FINAL,
-                    ResultCode.FAILED_INGEST_ENQUEUE,
-                    new ParticipationProcessedFailure(FailureClass.RETRYABLE, "RETRYABLE_EXHAUSTED", e.getMessage()),
-                    false
-            ));
-
-            log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (RETRYABLE_EXHAUSTED)",
-                    payload.requestId(), updated, attempt);
-
-            deleteMessage(message);
+            // dlq전략수정 : 내부에서 RETRYABLE_EXHAUSTED로 FAILED_FINAL 찍고 ACK하면 SQS redrive가 죽음.
+            // - attempt가 커져도 계속 "재시도"로 두고, 최종 DLQ 이동은 SQS redrive(maxReceiveCount)에 맡긴다.
+            int backoff = computeRetryableBackoffSeconds(attempt); // 이미 max 60초로 캡됨
+            log.warn("[RETRYABLE] requestId={} attempt={} backoff={}s rollbackToQueued={} (no-ack; rely on redrive)", //dlq전략수정 (warn로 낮춤)
+                    payload.requestId(), attempt, backoff, rolledBack, e);
+            deferMessage(message, backoff);
+            return; // ✅ ACK 금지 (deleteMessage 호출하면 안 됨)
         }
     }
 
@@ -385,18 +543,57 @@ public class SqsMessageConsumer {
     }
 
     private FailureClass classifyFailure(Exception e) {
-        if (e instanceof IllegalArgumentException) return FailureClass.NON_RETRYABLE;
 
+        // 1) 명백한 NonRetryable: 입력/스키마/파싱/비즈니스 규칙
+        if (e instanceof IllegalArgumentException) return FailureClass.NON_RETRYABLE; // 필수값 누락 등
+        if (e instanceof BusinessRuleViolationException) return FailureClass.NON_RETRYABLE; //dlq 전략수정 : 비즈니스 규칙 위반은 즉시 DLQ
+
+        //dlq 전략수정 : 네트워크/타임아웃은 Retryable로 “명시”
+        if (e instanceof SocketTimeoutException) return FailureClass.RETRYABLE;
+        if (e instanceof TimeoutException) return FailureClass.RETRYABLE;
+        if (e instanceof ConnectException) return FailureClass.RETRYABLE;
+        if (e instanceof UnknownHostException) return FailureClass.RETRYABLE;
+        if (e instanceof IOException) return FailureClass.RETRYABLE;
+
+        //dlq 전략수정 : AWS SDK(core) 예외는 의존성/버전에 따라 클래스가 없을 수 있으므로 이름으로 안전 판별
+        String cn = e.getClass().getName();
+        if (cn.endsWith("SdkClientException") || cn.contains(".core.exception.SdkClientException")) {
+            return FailureClass.RETRYABLE;
+        }
+
+        // 2) DynamoDB: throttling/일시 장애는 Retryable로 명확히 분기
+        // - DynamoDbException은 statusCode만으로 판단하면 Throttling(429 등)이 NonRetryable로 오판될 수 있음
+        // - SDK 버전에 따라 ThrottlingException/ServiceUnavailableException 클래스가 없을 수 있으므로 errorCode/statusCode로 처리한다.
+        if (e instanceof software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputExceededException)
+            return FailureClass.RETRYABLE;
+
+        // 4) SQS / DynamoDB 공통: 5xx는 Retryable, 4xx는 NonRetryable (단 throttling은 위에서 이미 처리)
         if (e instanceof SqsException se) {
             int sc = se.statusCode();
-            if (sc >= 400 && sc < 500) return FailureClass.NON_RETRYABLE;
+            if (sc >= 500) return FailureClass.RETRYABLE;
+            if (sc >= 400) return FailureClass.NON_RETRYABLE;
         }
 
         if (e instanceof DynamoDbException de) {
             int sc = de.statusCode();
-            if (sc >= 400 && sc < 500) return FailureClass.NON_RETRYABLE;
+
+            //dlq 전략수정 : throttling/limit 계열은 4xx여도 Retryable로 우선 처리
+            String code = de.awsErrorDetails() != null ? de.awsErrorDetails().errorCode() : null;
+            if (sc == 429) return FailureClass.RETRYABLE;
+            if (code != null) {
+                if ("ThrottlingException".equals(code) ||
+                        "Throttling".equals(code) ||
+                        "RequestLimitExceeded".equals(code) ||
+                        "ProvisionedThroughputExceededException".equals(code)) {
+                    return FailureClass.RETRYABLE;
+                }
+            }
+
+            if (sc >= 500) return FailureClass.RETRYABLE;
+            if (sc >= 400) return FailureClass.NON_RETRYABLE;
         }
 
+        // 5) 그 외는 기본 Retryable(일시 장애 가정)로 두는 게 안전
         return FailureClass.RETRYABLE;
     }
 

--- a/worker/src/main/java/com/teamA/async/worker/ddb/EventCapacityRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/EventCapacityRepository.java
@@ -1,6 +1,7 @@
 package com.teamA.async.worker.ddb;
 
 import com.teamA.async.common.ddb.keys.DdbKeyFactory;
+import com.teamA.async.worker.exception.BusinessRuleViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
@@ -8,6 +9,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 
 import java.time.Instant;
 import java.util.Map;
@@ -58,8 +60,40 @@ public class EventCapacityRepository {
             return true;
 
         } catch (ConditionalCheckFailedException e) {
+
+            //dlq전략수정 : "정원 마감" vs "이벤트 없음" 의미 분리
+            // - 조건 실패가 "0 이하"일 수도, 아이템이 없어서일 수도 있음
+            // - DLQ reasonCode를 의미있게 채우려면 여기서 구분해야 함
+            if (!existsEventConfigItem(eventId, key)) {
+                log.warn("[EVENT NOT FOUND] eventId={} (CONFIG item missing)", eventId);
+                throw new BusinessRuleViolationException(
+                        "EVENT_NOT_FOUND",
+                        "event config not found: " + eventId
+                );
+            }
+
             log.info("[CAPACITY FULL] eventId={} no remaining slot", eventId);
             return false;
+        }
+    }
+
+    //dlq전략수정 : 이벤트(CONFIG) 아이템 존재 여부 확인용
+    private boolean existsEventConfigItem(String eventId, Map<String, AttributeValue> key) {
+        try {
+            GetItemRequest getReq = GetItemRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .key(key)
+                    .projectionExpression("PK")
+                    .consistentRead(true)
+                    .build();
+
+            Map<String, AttributeValue> item = dynamoDbClient.getItem(getReq).item();
+            return item != null && !item.isEmpty();
+        } catch (Exception ex) {
+            // 존재 여부 확인 실패는 "일시 장애" 성격이 더 강하므로 여기서는 존재한다고 가정하지 말고
+            // 상위에서 Retryable로 처리되도록 예외를 그대로 올려도 되지만,
+            // 여기서는 tryDecrement의 시그니처를 유지하려고 "예외 재던지기"로 간다.
+            throw ex;
         }
     }
 }

--- a/worker/src/main/java/com/teamA/async/worker/ddb/RequestStateRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/RequestStateRepository.java
@@ -305,4 +305,70 @@ public class RequestStateRepository {
         return s.substring(0, maxLen);
     }
 
+    public boolean releaseProcessingToQueued(String requestId) {
+
+        Map<String, AttributeValue> key = Map.of(
+                ATTR_PK, AttributeValue.fromS(DdbKeyFactory.requestPk(requestId)),
+                ATTR_SK, AttributeValue.fromS(DdbKeyFactory.metaSk())
+        );
+
+        UpdateItemRequest req = UpdateItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                .conditionExpression("#status = :processing")
+                .updateExpression("SET #status = :queued")
+                .expressionAttributeNames(Map.of("#status", "status"))
+                .expressionAttributeValues(Map.of(
+                        ":processing", AttributeValue.fromS("PROCESSING"),
+                        ":queued", AttributeValue.fromS("QUEUED")
+                ))
+                .build();
+
+        try {
+            dynamoDbClient.updateItem(req);
+            return true;
+        } catch (ConditionalCheckFailedException e) {
+            return false;
+        }
+    }
+
+    // dlq전략수정 : "내가 선점했던 PROCESSING만" 안전하게 QUEUED로 롤백하기 위한 오버로드(권장)
+    // - startedAt(내가 기록했던 startedAt)까지 조건에 포함시켜 경합 시 다른 워커의 PROCESSING을 롤백하는 위험을 줄인다.
+    // - lastRetryAt을 같이 기록해 운영 시 추적성을 높인다.
+    public boolean releaseProcessingToQueued(String requestId, long startedAtMillis) { //dlq전략수정
+
+        Map<String, AttributeValue> key = Map.of(
+                ATTR_PK, AttributeValue.fromS(DdbKeyFactory.requestPk(requestId)),
+                ATTR_SK, AttributeValue.fromS(DdbKeyFactory.metaSk())
+        );
+
+        long now = System.currentTimeMillis(); //dlq전략수정
+
+        UpdateItemRequest req = UpdateItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                // status=PROCESSING 이면서 startedAt이 내가 선점한 startedAt과 동일할 때만 롤백 //dlq전략수정
+                .conditionExpression("#status = :processing AND #startedAt = :startedAt") //dlq전략수정
+                .updateExpression("SET #status = :queued, lastRetryAt = :now") //dlq전략수정
+                .expressionAttributeNames(Map.of(
+                        "#status", "status",
+                        "#startedAt", "startedAt"
+                ))
+                .expressionAttributeValues(Map.of(
+                        ":processing", AttributeValue.fromS("PROCESSING"),
+                        ":queued", AttributeValue.fromS("QUEUED"),
+                        ":startedAt", AttributeValue.fromN(Long.toString(startedAtMillis)), //dlq전략수정
+                        ":now", AttributeValue.fromN(Long.toString(now)) //dlq전략수정
+                ))
+                .build();
+
+        try {
+            dynamoDbClient.updateItem(req);
+            return true;
+        } catch (ConditionalCheckFailedException e) {
+            return false;
+        }
+    }
+
+
 }

--- a/worker/src/main/java/com/teamA/async/worker/ddb/WorkerIdempotencyRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/WorkerIdempotencyRepository.java
@@ -30,7 +30,9 @@ public class WorkerIdempotencyRepository {
         PutItemRequest req = PutItemRequest.builder()
                 .tableName(tableName)
                 .item(item)
-                .conditionExpression("attribute_not_exists(PK)")
+                .conditionExpression("attribute_not_exists(PK) OR #requestId = :rid") //dlq 전략수정
+                .expressionAttributeNames(Map.of("#requestId", "requestId"))
+                .expressionAttributeValues(Map.of(":rid", AttributeValue.fromS(requestId)))
                 .build();
 
         try {

--- a/worker/src/main/java/com/teamA/async/worker/dlq/DlqSender.java
+++ b/worker/src/main/java/com/teamA/async/worker/dlq/DlqSender.java
@@ -1,0 +1,184 @@
+package com.teamA.async.worker.dlq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+//dlq전략수정 : Micrometer 메트릭
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DlqSender {
+
+    private final SqsClient sqsClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${sqs.dlq-url}")
+    private String dlqUrl;
+
+
+    private final MeterRegistry meterRegistry;
+    private Counter dlqSendFailureCounter;
+
+    // dlq전략수정: workerVersion/workerId 메타를 고정해서 넣기
+    private String workerId() {
+        return Optional.ofNullable(System.getenv("HOSTNAME")).orElse("worker-local");
+    }
+
+    private String workerVersion() {
+        // dlq전략수정: ECS task env로 주입 추천 (ex. GIT_SHA, IMAGE_TAG)
+        return Optional.ofNullable(System.getenv("WORKER_VERSION")).orElse("unknown");
+    }
+
+    // dlq전략수정: SQS 256KB 제한 고려해서 너무 큰 body는 잘라 저장
+    private String truncate(String s, int maxLen) {
+        if (s == null) return null;
+        if (s.length() <= maxLen) return s;
+        return s.substring(0, maxLen) + "...(truncated)";
+    }
+
+    // dlq전략수정: stackTraceDigest(짧은 해시)
+    private String digest(String s) {
+        try {
+            if (s == null) return null;
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(s.getBytes(StandardCharsets.UTF_8));
+            // 앞 12 hex 정도면 충분
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 6; i++) { // 6 bytes => 12 hex
+                sb.append(String.format("%02x", hash[i]));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            return "digest_failed";
+        }
+    }
+
+    //dlq전략수정 : 메트릭 초기화(지연 초기화 방식)
+    private Counter dlqSendFailureCounter() {
+        if (dlqSendFailureCounter == null) {
+            dlqSendFailureCounter = Counter.builder("dlq_send_failure_count")
+                    .description("DLQ send failures (will cause retry to prevent loss)")
+                    .register(meterRegistry);
+        }
+        return dlqSendFailureCounter;
+    }
+
+    // 기존 호출부를 크게 바꾸지 않기 위해, 에러 정보는 optional로 받는 오버로드 형태 추천
+    public void send(
+            String originalBody,
+            String originalQueueMessageId,
+            int receiveCount,
+            String failureType,   // NON_RETRYABLE
+            String reasonCode,    // INVALID_SCHEMA / STALE_RECEIVED / ...
+            Map<String, String> keys
+    ) {
+        send(originalBody, originalQueueMessageId, receiveCount, failureType, reasonCode, keys, null);
+    }
+
+    // dlq전략수정: exception까지 받는 버전(가능하면 NonRetryable catch에서 이걸 쓰면 stackTraceDigest까지 완성됨)
+    public void send(
+            String originalBody,
+            String originalQueueMessageId,
+            int receiveCount,
+            String failureType,
+            String reasonCode,
+            Map<String, String> keys,
+            Exception exceptionOrNull
+    ) {
+        try {
+            String receivedAt = Instant.now().toString();
+            String workerId = workerId();
+            String workerVersion = workerVersion();
+
+            Map<String, Object> originalMeta = new HashMap<>();
+            originalMeta.put("queueMessageId", originalQueueMessageId);
+            originalMeta.put("receiveCount", receiveCount);
+            originalMeta.put("receivedAt", receivedAt);
+            originalMeta.put("workerId", workerId);
+            originalMeta.put("workerVersion", workerVersion);
+
+            Map<String, Object> error = null;
+            if (exceptionOrNull != null) {
+                String exClass = exceptionOrNull.getClass().getSimpleName();
+                String exMsg = exceptionOrNull.getMessage();
+                String digestBase = exClass + ":" + exMsg;
+                error = new HashMap<>();
+                error.put("exceptionClass", exClass);
+                error.put("message", truncate(exMsg, 300));
+                error.put("stackTraceDigest", digest(digestBase));
+            }
+
+            Map<String, Object> envelope = new HashMap<>();
+            envelope.put("failureType", failureType);
+            envelope.put("reasonCode", reasonCode);
+            envelope.put("keys", keys == null ? Map.of() : keys);
+            envelope.put("original", originalMeta);
+            if (error != null) envelope.put("error", error);
+
+            // dlq전략수정: 원본 payload 그대로 + 메타데이터 추가 원칙
+            envelope.put("originalBody", truncate(originalBody, 30_000)); // 넉넉히 잘라 저장
+
+            String body = objectMapper.writeValueAsString(envelope);
+
+            // MessageAttributes는 콘솔/필터링용(짧고 핵심만)
+            Map<String, MessageAttributeValue> attrs = new HashMap<>();
+            attrs.put("failureType", MessageAttributeValue.builder().dataType("String").stringValue(failureType).build());
+            attrs.put("reasonCode", MessageAttributeValue.builder().dataType("String").stringValue(reasonCode).build());
+            attrs.put("originalQueueMessageId", MessageAttributeValue.builder().dataType("String").stringValue(originalQueueMessageId).build());
+            attrs.put("workerVersion", MessageAttributeValue.builder().dataType("String").stringValue(workerVersion).build());
+            attrs.put("workerId", MessageAttributeValue.builder().dataType("String").stringValue(workerId).build());
+            attrs.put("receivedAt", MessageAttributeValue.builder().dataType("String").stringValue(receivedAt).build());
+
+            if (keys != null) {
+                keys.forEach((k, v) -> {
+                    if (v != null && !v.isBlank()) {
+                        attrs.put(k, MessageAttributeValue.builder().dataType("String").stringValue(v).build());
+                    }
+                });
+            }
+
+            //dlq전략수정 : DLQ 전송 로그(운영이 DLQ만 봐도 1분 내 분류 가능하게)
+            log.error("[DLQ SEND] failureType={} reasonCode={} keys={} originalQueueMessageId={} receiveCount={} workerVersion={}",
+                    failureType, reasonCode, (keys == null ? Map.of() : keys), originalQueueMessageId, receiveCount, workerVersion);
+
+            sqsClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(dlqUrl)
+                    .messageBody(body)
+                    .messageAttributes(attrs)
+                    .build());
+
+        } catch (Exception e) {
+            //dlq전략수정 : DLQ 전송 실패 메트릭(+ reasonCode 태깅)
+            try {
+                dlqSendFailureCounter().increment();
+                meterRegistry.counter("dlq_send_failure_count", "reasonCode",
+                                (reasonCode == null || reasonCode.isBlank()) ? "UNKNOWN" : reasonCode)
+                        .increment(); 
+            } catch (Exception ignore) {
+                // 메트릭 실패가 본 실패를 가리면 안 됨
+            }
+
+            //dlq전략수정 : 실패 로그(키 포함)
+            log.error("[DLQ SEND FAILED] failureType={} reasonCode={} keys={} originalQueueMessageId={} receiveCount={}",
+                    failureType, reasonCode, (keys == null ? Map.of() : keys), originalQueueMessageId, receiveCount, e);
+
+            // 중요: DLQ 전송 실패는 유실 방지를 위해 반드시 실패로 올려 재시도 타게 함
+            throw new RuntimeException("DLQ_SEND_FAILED", e);
+        }
+    }
+}

--- a/worker/src/main/java/com/teamA/async/worker/exception/BusinessRuleViolationException.java
+++ b/worker/src/main/java/com/teamA/async/worker/exception/BusinessRuleViolationException.java
@@ -1,0 +1,24 @@
+package com.teamA.async.worker.exception;
+
+//dlq 전략수정 : 비즈니스 규칙 위반을 NonRetryable로 명확히 하기 위한 공용 예외
+public class BusinessRuleViolationException extends RuntimeException {
+    private final String reasonCode;
+
+    public BusinessRuleViolationException(String reasonCode, String message) {
+        super(message);
+        this.reasonCode = (reasonCode == null || reasonCode.isBlank())
+                ? "BUSINESS_RULE_VIOLATION"
+                : reasonCode;
+    }
+
+    public BusinessRuleViolationException(String reasonCode) {
+        super(reasonCode);
+        this.reasonCode = (reasonCode == null || reasonCode.isBlank())
+                ? "BUSINESS_RULE_VIOLATION"
+                : reasonCode;
+    }
+
+    public String getReasonCode() {
+        return reasonCode;
+    }
+}

--- a/worker/src/main/resources/application-ecs.yml
+++ b/worker/src/main/resources/application-ecs.yml
@@ -9,6 +9,8 @@ ddb:
 
 sqs:
   queue-url: ${SQS_QUEUE_URL}
+  dlq-url: ${DLQ_QUEUE_URL}
+
 
 analytics:
   event:

--- a/worker/src/main/resources/application.yml
+++ b/worker/src/main/resources/application.yml
@@ -9,6 +9,7 @@ ddb:
 
 sqs:
   queue-url: ${SQS_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/590807098068/AsyncEventMainQueue}
+  dlq-url: ${DLQ_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/590807098068/AsyncEventDLQ}
 
 analytics:
   event:


### PR DESCRIPTION
related to #91

## 📌 작업 내용
- Async Worker의 DLQ 전략 및 재시도/멱등성 처리 구조를 개선하여  
  실패를 의미 기반(Duplicate / NonRetryable / Retryable)으로 명확히 분리함.
- DLQ 메시지를 운영자가 즉시 원인 파악 가능하도록 구조화하고,
  중복·일시 장애로 인한 불필요한 재시도/DLQ 오염을 제거함.

## 🔍 작업 상세
- [x] Worker 메시지 처리 플로우를 ACK / Retry / DLQ 기준으로 명확히 고정
- [x] DynamoDB 기반 멱등성(Idempotency) 실패를 Duplicate로 분리하여 즉시 ACK 처리
- [x] 상태 머신(CAS) 선점 실패를 경합(Duplicate)으로 간주하여 재시도/DLQ 방지
- [x] Retryable / NonRetryable 실패 분류 로직을 코드 레벨에서 명시적으로 정의
- [x] NonRetryable 실패를 Worker에서 즉시 DLQ로 전송하는 방식으로 전환
- [x] DLQ 메시지 포맷을 원본 payload + 메타데이터(envelope) 구조로 재설계
- [x] DLQ에 failureType, reasonCode, 주요 키(requestId/eventId/userId) 포함
- [x] 비즈니스 규칙 위반(BusinessRuleViolationException)을 NonRetryable로 명확히 분리
- [x] 네트워크/DynamoDB throttling/5xx 오류를 Retryable로 명확히 분류
- [x] 운영 가시성 강화를 위해 메트릭 추가
  - duplicate_skip_count
  - non_retryable_dlq_count (reasonCode 태깅)
  - retryable_exception_count
- [x] DLQ 전송 실패 시 메시지 유실 방지를 위한 예외 전파 처리 추가


