### PR TITLE
feat/dlq-modify02

### DIFF
--- a/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
+++ b/worker/src/main/java/com/teamA/async/worker/consumer/SqsMessageConsumer.java
@@ -188,188 +188,193 @@ public class SqsMessageConsumer {
             }
         }
 
-        // Worker 책임 — 항상 실행
-        boolean first = idempotencyRepository.tryLock(
-                payload.eventId(),
-                payload.userId(),
-                payload.requestId()
-        );
+        // ================================
+        // ✅ [수정] 상태 생성/전이까지 포함해서
+        //    "분류 try/catch" 아래로 통일
+        // ================================
+        try {
 
-        if (!first) {
-            log.info("[DUPLICATE] skip requestId={}", payload.requestId());
-            if (duplicateSkipCounter != null) duplicateSkipCounter.increment(); //dlq 전략수정
-            deleteMessage(message);
-            return;
-        }
+            // Worker 책임 — 항상 실행
+            boolean first = idempotencyRepository.tryLock(
+                    payload.eventId(),
+                    payload.userId(),
+                    payload.requestId()
+            );
 
-        log.info("[LOCKED] requestId={} eventId={} userId={}",
-                payload.requestId(),
-                payload.eventId(),
-                payload.userId());
-
-        // 최초 상태 생성
-        requestStateRepository.createReceived(
-                payload.requestId(),
-                payload.eventId(),
-                payload.userId(),
-                payload.eventType(),
-                payload.queuedAt()
-        );
-
-        // QUEUED 기록
-        requestStateRepository.markQueued(
-                payload.requestId(),
-                payload.queuedAt()
-        );
-
-        // 3) QUEUED -> PROCESSING 선점
-        boolean acquired = requestStateRepository.tryAcquireProcessing(payload.requestId(), startedAt);
-        if (!acquired) {
-            Optional<String> cur = requestStateRepository.getCurrentStatus(payload.requestId());
-
-            if (cur.isEmpty()) {
-                log.info("[SKIP] requestId={} no item found, attempt={} (ghost msg -> ack)", payload.requestId(), attempt);
+            if (!first) {
+                log.info("[DUPLICATE] skip requestId={}", payload.requestId());
+                if (duplicateSkipCounter != null) duplicateSkipCounter.increment(); //dlq 전략수정
                 deleteMessage(message);
                 return;
             }
 
-            String status = cur.get();
-            switch (status) {
-                case "RECEIVED":
-                    // [수정] RECEIVED 무한 defer 방지
-                    if (attempt <= MAX_RECEIVED_RETRY) {
-                        log.info("[DEFER] requestId={} status={} attempt={} (wait ingest -> retry)", payload.requestId(), status, attempt);
-                        deferMessage(message, VISIBILITY_DELAY_SECONDS);
+            log.info("[LOCKED] requestId={} eventId={} userId={}",
+                    payload.requestId(),
+                    payload.eventId(),
+                    payload.userId());
+
+            // 최초 상태 생성
+            requestStateRepository.createReceived(
+                    payload.requestId(),
+                    payload.eventId(),
+                    payload.userId(),
+                    payload.eventType(),
+                    payload.queuedAt()
+            );
+
+            // QUEUED 기록
+            requestStateRepository.markQueued(
+                    payload.requestId(),
+                    payload.queuedAt()
+            );
+
+            // 3) QUEUED -> PROCESSING 선점
+            boolean acquired = requestStateRepository.tryAcquireProcessing(payload.requestId(), startedAt);
+            if (!acquired) {
+                Optional<String> cur = requestStateRepository.getCurrentStatus(payload.requestId());
+
+                if (cur.isEmpty()) {
+                    log.info("[SKIP] requestId={} no item found, attempt={} (ghost msg -> ack)", payload.requestId(), attempt);
+                    deleteMessage(message);
+                    return;
+                }
+
+                String status = cur.get();
+                switch (status) {
+                    case "RECEIVED":
+                        // [수정] RECEIVED 무한 defer 방지
+                        if (attempt <= MAX_RECEIVED_RETRY) {
+                            log.info("[DEFER] requestId={} status={} attempt={} (wait ingest -> retry)", payload.requestId(), status, attempt);
+                            deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                            return;
+                        }
+
+                        long finishedAt = System.currentTimeMillis();
+                        boolean updated = requestStateRepository.markFailedFinal(
+                                payload.requestId(),
+                                finishedAt,
+                                ResultCode.FAILED_INGEST_ENQUEUE,
+                                FailureClass.NON_RETRYABLE,
+                                "STALE_RECEIVED",
+                                "Request stuck in RECEIVED state"
+                        );
+
+                        publisher.publish(buildEvent(
+                                payload, attempt, IS_DLQ,
+                                startedAt, finishedAt,
+                                RequestStatus.FAILED_FINAL,
+                                ResultCode.FAILED_INGEST_ENQUEUE,
+                                new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "STALE_RECEIVED", "Exceeded RECEIVED retry limit"),
+                                false
+                        ));
+
+                        log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (STALE_RECEIVED)",
+                                payload.requestId(), updated, attempt);
+
+                        String nonRetryableReasonCode = "STALE_RECEIVED"; //dlq 전략수정 : undefined symbol 해결
+
+                        if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
+                        meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode)
+                                .increment();
+
+                        log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
+                                nonRetryableReasonCode, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
+
+                        // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK (send 실패 시 delete까지 가지 않아서 재시도됨)
+                        dlqSender.send(
+                                message.body(),
+                                message.messageId(),
+                                attempt,
+                                "NON_RETRYABLE",
+                                nonRetryableReasonCode,
+                                Map.of(
+                                        "requestId", payload.requestId(),
+                                        "eventId", payload.eventId(),
+                                        "userId", payload.userId()
+                                )
+                        );
+
+                        deleteMessage(message);
                         return;
-                    }
-
-                    long finishedAt = System.currentTimeMillis();
-                    boolean updated = requestStateRepository.markFailedFinal(
-                            payload.requestId(),
-                            finishedAt,
-                            ResultCode.FAILED_INGEST_ENQUEUE,
-                            FailureClass.NON_RETRYABLE,
-                            "STALE_RECEIVED",
-                            "Request stuck in RECEIVED state"
-                    );
-
-                    publisher.publish(buildEvent(
-                            payload, attempt, IS_DLQ,
-                            startedAt, finishedAt,
-                            RequestStatus.FAILED_FINAL,
-                            ResultCode.FAILED_INGEST_ENQUEUE,
-                            new ParticipationProcessedFailure(FailureClass.NON_RETRYABLE, "STALE_RECEIVED", "Exceeded RECEIVED retry limit"),
-                            false
-                    ));
-
-                    log.warn("[FAILED_FINAL] requestId={} updated={} attempt={} (STALE_RECEIVED)",
-                            payload.requestId(), updated, attempt);
-
-                    String nonRetryableReasonCode = "STALE_RECEIVED"; //dlq 전략수정 : undefined symbol 해결
-
-                    if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
-                    meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode)
-                            .increment();
-
-                    log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
-                            nonRetryableReasonCode, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
-
-                    // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK (send 실패 시 delete까지 가지 않아서 재시도됨)
-                    dlqSender.send(
-                            message.body(),
-                            message.messageId(),
-                            attempt,
-                            "NON_RETRYABLE",
-                            nonRetryableReasonCode,
-                            Map.of(
-                                    "requestId", payload.requestId(),
-                                    "eventId", payload.eventId(),
-                                    "userId", payload.userId()
-                            )
-                    );
-
-                    deleteMessage(message);
-                    return;
-                case "QUEUED":
-                    log.info("[SKIP] requestId={} status={} attempt={} (race/contend -> ack)", payload.requestId(), status, attempt);
-                    finishedAt = System.currentTimeMillis();
-                    publisher.publish(buildEvent(
-                            payload, attempt, IS_DLQ,
-                            startedAt, finishedAt,
-                            RequestStatus.REJECTED,
-                            ResultCode.DUPLICATE_SKIPPED,
-                            null,
-                            true
-                    ));
-                    deleteMessage(message);
-                    return;
-                case "PROCESSING":
-                    // 다른 워커가 처리 중이거나, 이전 시도에서 visibility timeout으로 재수신된 케이스
-                    // ✅ 바로 ACK하면 유실/오판 위험. 잠깐 defer로 밀어줌.
-                    if (attempt <= MAX_RETRYABLE_RETRY) {
-                        log.info("[DEFER] requestId={} status=PROCESSING attempt={} (in-flight -> retry later)",
-                                payload.requestId(), attempt);
-                        deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                    case "QUEUED":
+                        log.info("[SKIP] requestId={} status={} attempt={} (race/contend -> ack)", payload.requestId(), status, attempt);
+                        finishedAt = System.currentTimeMillis();
+                        publisher.publish(buildEvent(
+                                payload, attempt, IS_DLQ,
+                                startedAt, finishedAt,
+                                RequestStatus.REJECTED,
+                                ResultCode.DUPLICATE_SKIPPED,
+                                null,
+                                true
+                        ));
+                        deleteMessage(message);
                         return;
-                    }
+                    case "PROCESSING":
+                        // 다른 워커가 처리 중이거나, 이전 시도에서 visibility timeout으로 재수신된 케이스
+                        // ✅ 바로 ACK하면 유실/오판 위험. 잠깐 defer로 밀어줌.
+                        if (attempt <= MAX_RETRYABLE_RETRY) {
+                            log.info("[DEFER] requestId={} status=PROCESSING attempt={} (in-flight -> retry later)",
+                                    payload.requestId(), attempt);
+                            deferMessage(message, VISIBILITY_DELAY_SECONDS);
+                            return;
+                        }
 
-                    // ✅ 너무 오래 PROCESSING이면 "의미 있는 실패"로 보고 즉시 DLQ + ACK (선택적으로)
-                    long finishedAt2 = System.currentTimeMillis();
-                    requestStateRepository.markFailedFinal(
-                            payload.requestId(),
-                            finishedAt2,
-                            ResultCode.FAILED_WORKER_EXCEPTION,
-                            FailureClass.NON_RETRYABLE,
-                            "STALE_PROCESSING",
-                            "Request stuck in PROCESSING state"
-                    );
+                        // ✅ 너무 오래 PROCESSING이면 "의미 있는 실패"로 보고 즉시 DLQ + ACK (선택적으로)
+                        long finishedAt2 = System.currentTimeMillis();
+                        requestStateRepository.markFailedFinal(
+                                payload.requestId(),
+                                finishedAt2,
+                                ResultCode.FAILED_WORKER_EXCEPTION,
+                                FailureClass.NON_RETRYABLE,
+                                "STALE_PROCESSING",
+                                "Request stuck in PROCESSING state"
+                        );
 
-                    String nonRetryableReasonCode2 = "STALE_PROCESSING"; //dlq 전략수정 : undefined symbol 해결
+                        String nonRetryableReasonCode2 = "STALE_PROCESSING"; //dlq 전략수정 : undefined symbol 해결
 
-                    if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
-                    meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode2)
-                            .increment();
+                        if (nonRetryableDlqCounter != null) nonRetryableDlqCounter.increment();
+                        meterRegistry.counter("non_retryable_dlq_count", "reasonCode", nonRetryableReasonCode2)
+                                .increment();
 
-                    log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
-                            nonRetryableReasonCode2, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
+                        log.error("[DLQ SEND] reasonCode={} requestId={} eventId={} userId={} attempt={} messageId={}",
+                                nonRetryableReasonCode2, payload.requestId(), payload.eventId(), payload.userId(), attempt, message.messageId());
 
-                    // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK
-                    dlqSender.send(
-                            message.body(),
-                            message.messageId(),
-                            attempt,
-                            "NON_RETRYABLE",
-                            nonRetryableReasonCode2,
-                            Map.of(
-                                    "requestId", payload.requestId(),
-                                    "eventId", payload.eventId(),
-                                    "userId", payload.userId()
-                            )
-                    );
-                    deleteMessage(message);
-                    return;
+                        // dlq전략수정 : NonRetryable은 즉시 DLQ 전송 + ACK
+                        dlqSender.send(
+                                message.body(),
+                                message.messageId(),
+                                attempt,
+                                "NON_RETRYABLE",
+                                nonRetryableReasonCode2,
+                                Map.of(
+                                        "requestId", payload.requestId(),
+                                        "eventId", payload.eventId(),
+                                        "userId", payload.userId()
+                                )
+                        );
+                        deleteMessage(message);
+                        return;
 
-                default:
-                    log.info("[SKIP] requestId={} status={} attempt={} (dup -> ack)", payload.requestId(), status, attempt);
-                    finishedAt = System.currentTimeMillis();
-                    publisher.publish(buildEvent(
-                            payload, attempt, IS_DLQ,
-                            startedAt, finishedAt,
-                            RequestStatus.SUCCEEDED,
-                            ResultCode.SUCCESS,
-                            null,
-                            true
-                    ));
-                    deleteMessage(message);
-                    return;
+                    default:
+                        log.info("[SKIP] requestId={} status={} attempt={} (dup -> ack)", payload.requestId(), status, attempt);
+                        finishedAt = System.currentTimeMillis();
+                        publisher.publish(buildEvent(
+                                payload, attempt, IS_DLQ,
+                                startedAt, finishedAt,
+                                RequestStatus.SUCCEEDED,
+                                ResultCode.SUCCESS,
+                                null,
+                                true
+                        ));
+                        deleteMessage(message);
+                        return;
+                }
             }
-        }
 
-        // [추가 로그 1] PROCESSING 선점 성공
-        log.info("[ACQUIRED] requestId={} attempt={} startedAt={}",
-                payload.requestId(), attempt, startedAt);
+            // [추가 로그 1] PROCESSING 선점 성공
+            log.info("[ACQUIRED] requestId={} attempt={} startedAt={}",
+                    payload.requestId(), attempt, startedAt);
 
-        try {
             final long finishedAt;
             final RequestStatus finalStatus;
             final ResultCode resultCode;

--- a/worker/src/main/java/com/teamA/async/worker/ddb/EventCapacityRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/EventCapacityRepository.java
@@ -4,6 +4,7 @@ import com.teamA.async.common.ddb.keys.DdbKeyFactory;
 import com.teamA.async.worker.exception.BusinessRuleViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -21,7 +22,12 @@ public class EventCapacityRepository {
 
     private final DynamoDbClient dynamoDbClient;
 
-    private static final String TABLE_NAME = "AsyncEventTable";
+    @Value("${ddb.tables.event-capacity}")
+    private String tableName;
+
+
+    // ✅ (2번) SK "CONFIG" 매직 스트링 제거: 한 곳에서만 관리
+    private static final String EVENT_CONFIG_SK = "CONFIG";
 
     /**
      * capacityRemaining > 0 인 경우에만 1 감소
@@ -30,16 +36,15 @@ public class EventCapacityRepository {
 
         // 🔒 키팩토리 단일 진실 사용
         Map<String, AttributeValue> key = Map.of(
-                "PK", AttributeValue.builder()
-                        .s(DdbKeyFactory.eventPk(eventId))
-                        .build(),
-                "SK", AttributeValue.builder()
-                        .s("CONFIG") // ❗ 키팩토리에 메서드는 없고 상수만 존재
+                "eventId", AttributeValue.builder()
+                        // ✅ event-capacity 테이블은 PK-only(eventId) 구조이므로 "eventId"만 사용한다
+                        // ⚠️ DdbKeyFactory.eventPk(...)는 PK/SK 기반 설계에서 쓰는 값일 수 있어 일단 eventId 그대로 사용
+                        .s(eventId)
                         .build()
         );
 
         UpdateItemRequest request = UpdateItemRequest.builder()
-                .tableName(TABLE_NAME)
+                .tableName(tableName)
                 .key(key)
                 .conditionExpression("capacityRemaining > :zero")
                 .updateExpression(
@@ -81,9 +86,9 @@ public class EventCapacityRepository {
     private boolean existsEventConfigItem(String eventId, Map<String, AttributeValue> key) {
         try {
             GetItemRequest getReq = GetItemRequest.builder()
-                    .tableName(TABLE_NAME)
+                    .tableName(tableName)
                     .key(key)
-                    .projectionExpression("PK")
+                    .projectionExpression("eventId")
                     .consistentRead(true)
                     .build();
 

--- a/worker/src/main/java/com/teamA/async/worker/ddb/RequestStateRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/RequestStateRepository.java
@@ -1,6 +1,5 @@
 package com.teamA.async.worker.ddb;
 
-import com.teamA.async.common.ddb.keys.DdbKeyFactory;
 import com.teamA.async.common.domain.enums.FailureClass;
 import com.teamA.async.common.domain.enums.ResultCode;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +9,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
 import com.teamA.async.common.domain.enums.EventType;
-
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,11 +20,10 @@ public class RequestStateRepository {
 
     private final DynamoDbClient dynamoDbClient;
 
-    @Value("${ddb.table-name}")
+    @Value("${ddb.tables.request-state}")
     private String tableName;
 
-    private static final String ATTR_PK = "PK";
-    private static final String ATTR_SK = "SK";
+    private static final String ATTR_REQUEST_ID = "requestId";
 
     /**
      * QUEUED -> PROCESSING 선점
@@ -45,22 +42,19 @@ public class RequestStateRepository {
                 (System.currentTimeMillis() / 1000) + (60L * 60 * 24 * 30); // 30일
 
         Map<String, AttributeValue> item = Map.of(
-                ATTR_PK, AttributeValue.fromS(DdbKeyFactory.requestPk(requestId)),
-                ATTR_SK, AttributeValue.fromS(DdbKeyFactory.metaSk()),
-                "requestId", AttributeValue.fromS(requestId),
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId), // ✅ PK-only (requestId)
                 "eventId", AttributeValue.fromS(eventId),
                 "userId", AttributeValue.fromS(userId),
                 "status", AttributeValue.fromS("RECEIVED"),
                 "requestedAt", AttributeValue.fromN(Long.toString(requestedAt)),
                 "eventType", AttributeValue.fromS(eventType.name()),
-
                 "ttl", AttributeValue.fromN(Long.toString(ttlEpochSeconds))
         );
 
         PutItemRequest req = PutItemRequest.builder()
                 .tableName(tableName)
                 .item(item)
-                .conditionExpression("attribute_not_exists(PK)")
+                .conditionExpression("attribute_not_exists(requestId)")
                 .build();
 
         try {
@@ -68,14 +62,12 @@ public class RequestStateRepository {
         } catch (ConditionalCheckFailedException e) {
             // 이미 있으면 그냥 통과 (중복 생성 방지)
         }
-
     }
 
     public void markQueued(String requestId, long queuedAtMillis) {
 
         Map<String, AttributeValue> key = Map.of(
-                ATTR_PK, AttributeValue.fromS(DdbKeyFactory.requestPk(requestId)),
-                ATTR_SK, AttributeValue.fromS(DdbKeyFactory.metaSk())
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId)
         );
 
         UpdateItemRequest req = UpdateItemRequest.builder()
@@ -101,8 +93,7 @@ public class RequestStateRepository {
     public boolean tryAcquireProcessing(String requestId, long startedAtMillis) {
 
         Map<String, AttributeValue> key = Map.of(
-                ATTR_PK, AttributeValue.builder().s(DdbKeyFactory.requestPk(requestId)).build(),
-                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.metaSk()).build()
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId)
         );
 
         UpdateItemRequest req = UpdateItemRequest.builder()
@@ -115,9 +106,9 @@ public class RequestStateRepository {
                         "#startedAt", "startedAt"
                 ))
                 .expressionAttributeValues(Map.of(
-                        ":queued", AttributeValue.builder().s("QUEUED").build(),
-                        ":processing", AttributeValue.builder().s("PROCESSING").build(),
-                        ":startedAt", AttributeValue.builder().n(String.valueOf(startedAtMillis)).build()
+                        ":queued", AttributeValue.fromS("QUEUED"),
+                        ":processing", AttributeValue.fromS("PROCESSING"),
+                        ":startedAt", AttributeValue.fromN(String.valueOf(startedAtMillis))
                 ))
                 .build();
 
@@ -128,7 +119,6 @@ public class RequestStateRepository {
             return false;
         }
     }
-
 
     /**
      * PROCESSING -> SUCCEEDED
@@ -155,7 +145,7 @@ public class RequestStateRepository {
                 "REJECTED",
                 "REJECTED",
                 ResultCode.REJECTED_CAPACITY,
-                null, // ✅ REJECT는 failure로 보지 않는 편(분석 일관성)
+                null,
                 finishedAtMillis,
                 null,
                 null
@@ -164,7 +154,6 @@ public class RequestStateRepository {
 
     /**
      * PROCESSING -> FAILED_FINAL
-     * - 실패는 분석을 위해 errorCode/errorMessage도 남긴다(선택)
      */
     public boolean markFailedFinal(
             String requestId,
@@ -186,12 +175,6 @@ public class RequestStateRepository {
         );
     }
 
-
-    /**
-     * 최종 상태 공통 업데이트
-     * - Condition: status = PROCESSING
-     * - Update: status/finishedAt/uiResult/resultCode(+ failureClass?) (+ errorCode/errorMessage?)
-     */
     private boolean updateFinalStatus(
             String requestId,
             String targetStatus,
@@ -203,11 +186,9 @@ public class RequestStateRepository {
             String errorMessage
     ) {
         Map<String, AttributeValue> key = Map.of(
-                ATTR_PK, AttributeValue.builder().s(DdbKeyFactory.requestPk(requestId)).build(),
-                ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.metaSk()).build()
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId)
         );
 
-        // DDB 안전: 너무 긴 메시지는 잘라서 저장(아이템 사이즈/로그 폭주 방지)
         String safeErrorMessage = truncate(errorMessage, 500);
 
         Map<String, String> names = new HashMap<>();
@@ -218,30 +199,30 @@ public class RequestStateRepository {
         names.put("#uiResult", "uiResult");
         names.put("#resultCode", "resultCode");
 
-        values.put(":processing", AttributeValue.builder().s("PROCESSING").build());
-        values.put(":target", AttributeValue.builder().s(targetStatus).build());
-        values.put(":finishedAt", AttributeValue.builder().n(String.valueOf(finishedAtMillis)).build());
-        values.put(":uiResult", AttributeValue.builder().s(uiResult).build());
-        values.put(":resultCode", AttributeValue.builder().s(resultCode.name()).build());
+        values.put(":processing", AttributeValue.fromS("PROCESSING"));
+        values.put(":target", AttributeValue.fromS(targetStatus));
+        values.put(":finishedAt", AttributeValue.fromN(String.valueOf(finishedAtMillis)));
+        values.put(":uiResult", AttributeValue.fromS(uiResult));
+        values.put(":resultCode", AttributeValue.fromS(resultCode.name()));
 
         String updateExpr =
                 "SET #status = :target, #finishedAt = :finishedAt, #uiResult = :uiResult, #resultCode = :resultCode";
 
         if (failureClass != null) {
             names.put("#failureClass", "failureClass");
-            values.put(":failureClass", AttributeValue.builder().s(failureClass.name()).build());
+            values.put(":failureClass", AttributeValue.fromS(failureClass.name()));
             updateExpr += ", #failureClass = :failureClass";
         }
 
         if (errorCode != null && !errorCode.isBlank()) {
             names.put("#errorCode", "errorCode");
-            values.put(":errorCode", AttributeValue.builder().s(errorCode).build());
+            values.put(":errorCode", AttributeValue.fromS(errorCode));
             updateExpr += ", #errorCode = :errorCode";
         }
 
         if (safeErrorMessage != null && !safeErrorMessage.isBlank()) {
             names.put("#errorMessage", "errorMessage");
-            values.put(":errorMessage", AttributeValue.builder().s(safeErrorMessage).build());
+            values.put(":errorMessage", AttributeValue.fromS(safeErrorMessage));
             updateExpr += ", #errorMessage = :errorMessage";
         }
 
@@ -264,16 +245,18 @@ public class RequestStateRepository {
 
     /**
      * 상태 조회 (선점 실패 시 로깅/분기용)
+     *
+     * ✅ 수정 포인트:
+     * - DynamoDB 일시 장애를 Optional.empty()로 삼키지 않는다
+     * - 상위에서 Retryable로 분류되도록 예외를 그대로 던진다
      */
     public Optional<String> getCurrentStatus(String requestId) {
 
+        Map<String, AttributeValue> key = Map.of(
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId)
+        );
+
         try {
-
-            Map<String, AttributeValue> key = Map.of(
-                    ATTR_PK, AttributeValue.builder().s(DdbKeyFactory.requestPk(requestId)).build(),
-                    ATTR_SK, AttributeValue.builder().s(DdbKeyFactory.metaSk()).build()
-            );
-
             GetItemRequest request = GetItemRequest.builder()
                     .tableName(tableName)
                     .key(key)
@@ -292,12 +275,11 @@ public class RequestStateRepository {
             return Optional.ofNullable(item.get("status"))
                     .map(AttributeValue::s);
 
-        } catch (Exception e) {
-            // 상태 조회 실패 → 안전하게 empty 처리
-            return Optional.empty();
+        } catch (DynamoDbException e) {
+            // ✅ 일시 장애는 상위에서 Retryable로 처리되도록 그대로 던진다
+            throw e;
         }
     }
-
 
     private static String truncate(String s, int maxLen) {
         if (s == null) return null;
@@ -308,8 +290,7 @@ public class RequestStateRepository {
     public boolean releaseProcessingToQueued(String requestId) {
 
         Map<String, AttributeValue> key = Map.of(
-                ATTR_PK, AttributeValue.fromS(DdbKeyFactory.requestPk(requestId)),
-                ATTR_SK, AttributeValue.fromS(DdbKeyFactory.metaSk())
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId)
         );
 
         UpdateItemRequest req = UpdateItemRequest.builder()
@@ -332,24 +313,19 @@ public class RequestStateRepository {
         }
     }
 
-    // dlq전략수정 : "내가 선점했던 PROCESSING만" 안전하게 QUEUED로 롤백하기 위한 오버로드(권장)
-    // - startedAt(내가 기록했던 startedAt)까지 조건에 포함시켜 경합 시 다른 워커의 PROCESSING을 롤백하는 위험을 줄인다.
-    // - lastRetryAt을 같이 기록해 운영 시 추적성을 높인다.
-    public boolean releaseProcessingToQueued(String requestId, long startedAtMillis) { //dlq전략수정
+    public boolean releaseProcessingToQueued(String requestId, long startedAtMillis) {
 
         Map<String, AttributeValue> key = Map.of(
-                ATTR_PK, AttributeValue.fromS(DdbKeyFactory.requestPk(requestId)),
-                ATTR_SK, AttributeValue.fromS(DdbKeyFactory.metaSk())
+                ATTR_REQUEST_ID, AttributeValue.fromS(requestId)
         );
 
-        long now = System.currentTimeMillis(); //dlq전략수정
+        long now = System.currentTimeMillis();
 
         UpdateItemRequest req = UpdateItemRequest.builder()
                 .tableName(tableName)
                 .key(key)
-                // status=PROCESSING 이면서 startedAt이 내가 선점한 startedAt과 동일할 때만 롤백 //dlq전략수정
-                .conditionExpression("#status = :processing AND #startedAt = :startedAt") //dlq전략수정
-                .updateExpression("SET #status = :queued, lastRetryAt = :now") //dlq전략수정
+                .conditionExpression("#status = :processing AND #startedAt = :startedAt")
+                .updateExpression("SET #status = :queued, lastRetryAt = :now")
                 .expressionAttributeNames(Map.of(
                         "#status", "status",
                         "#startedAt", "startedAt"
@@ -357,8 +333,8 @@ public class RequestStateRepository {
                 .expressionAttributeValues(Map.of(
                         ":processing", AttributeValue.fromS("PROCESSING"),
                         ":queued", AttributeValue.fromS("QUEUED"),
-                        ":startedAt", AttributeValue.fromN(Long.toString(startedAtMillis)), //dlq전략수정
-                        ":now", AttributeValue.fromN(Long.toString(now)) //dlq전략수정
+                        ":startedAt", AttributeValue.fromN(Long.toString(startedAtMillis)),
+                        ":now", AttributeValue.fromN(Long.toString(now))
                 ))
                 .build();
 
@@ -369,6 +345,4 @@ public class RequestStateRepository {
             return false;
         }
     }
-
-
 }

--- a/worker/src/main/java/com/teamA/async/worker/ddb/WorkerIdempotencyRepository.java
+++ b/worker/src/main/java/com/teamA/async/worker/ddb/WorkerIdempotencyRepository.java
@@ -14,23 +14,23 @@ public class WorkerIdempotencyRepository {
 
     private final DynamoDbClient dynamoDbClient;
 
-    @Value("${ddb.table-name}")
+    @Value("${ddb.tables.worker-idempotency}")
     private String tableName;
+
 
     public boolean tryLock(String eventId, String userId, String requestId) {
 
         String pk = "IDEMP#" + eventId + "#" + userId;
 
         Map<String, AttributeValue> item = Map.of(
-                "PK", AttributeValue.fromS(pk),
-                "SK", AttributeValue.fromS("LOCK"),
+                "idempotencyKey", AttributeValue.fromS(pk),     // ✅ PK-only 테이블 키
                 "requestId", AttributeValue.fromS(requestId)
         );
 
         PutItemRequest req = PutItemRequest.builder()
                 .tableName(tableName)
                 .item(item)
-                .conditionExpression("attribute_not_exists(PK) OR #requestId = :rid") //dlq 전략수정
+                .conditionExpression("attribute_not_exists(idempotencyKey) OR #requestId = :rid") //dlq 전략수정
                 .expressionAttributeNames(Map.of("#requestId", "requestId"))
                 .expressionAttributeValues(Map.of(":rid", AttributeValue.fromS(requestId)))
                 .build();

--- a/worker/src/main/java/com/teamA/async/worker/dlq/DlqSender.java
+++ b/worker/src/main/java/com/teamA/async/worker/dlq/DlqSender.java
@@ -168,7 +168,7 @@ public class DlqSender {
                 dlqSendFailureCounter().increment();
                 meterRegistry.counter("dlq_send_failure_count", "reasonCode",
                                 (reasonCode == null || reasonCode.isBlank()) ? "UNKNOWN" : reasonCode)
-                        .increment(); 
+                        .increment();
             } catch (Exception ignore) {
                 // 메트릭 실패가 본 실패를 가리면 안 됨
             }

--- a/worker/src/main/resources/application-ecs.yml
+++ b/worker/src/main/resources/application-ecs.yml
@@ -5,7 +5,10 @@ aws:
   region: ${AWS_REGION:ap-northeast-2}
 
 ddb:
-  table-name: ${DDB_TABLE_NAME:AsyncEventTable}
+  tables:
+    event-capacity: event-capacity
+    request-state: request-state
+    worker-idempotency: worker-idempotency
 
 sqs:
   queue-url: ${SQS_QUEUE_URL}

--- a/worker/src/main/resources/application.yml
+++ b/worker/src/main/resources/application.yml
@@ -5,11 +5,15 @@ aws:
   region: ap-northeast-2
 
 ddb:
-  table-name: AsyncEventTable
+  tables:
+    event-capacity: event-capacity
+    request-state: request-state
+    worker-idempotency: worker-idempotency
+
 
 sqs:
-  queue-url: ${SQS_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/590807098068/AsyncEventMainQueue}
-  dlq-url: ${DLQ_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/590807098068/AsyncEventDLQ}
+  queue-url: ${SQS_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/031988646316/async-main-queue}
+  dlq-url: ${DLQ_QUEUE_URL:https://sqs.ap-northeast-2.amazonaws.com/031988646316/async-main-dlq}
 
 analytics:
   event:


### PR DESCRIPTION
related to #91

## 📌 작업 내용
- DynamoDB 테이블 구조(3개 분리)에 맞춰 Worker 저장소 레이어를 정합성 있게 수정하고,
- DLQ 전략 및 재시도 정책이 의도대로 동작하도록 Repository 구현을 정리했습니다.

## 🔍 작업 상세
- [x] `event-capacity` 테이블을 **PK-only(eventId 단일키)** 구조로 확정하고 `EventCapacityRepository` 수정
- [x] `request-state` 테이블을 **requestId 단일키 상태 머신**으로 정리하고 모든 접근 키 통일
- [ ] `worker-idempotency` 테이블을 **idempotencyKey 단일키** 기반 멱등성 락으로 수정
- [ ] DynamoDB 일시 장애를 ghost message로 오판하지 않도록 `getCurrentStatus()` 예외 처리 개선
- [ ] Repository별 DynamoDB 테이블 설정 분리(`ddb.tables.*`) 적용
- [ ] Duplicate / Retryable / NonRetryable 흐름이 DLQ 전략과 일관되게 동작하도록 구조 정렬

